### PR TITLE
add go dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ We will create them again. (Caused problem on my rpi.)
     go get gopkg.in/ini.v1
     go get github.com/secsy/goftp
     go get golang.org/x/exp/io/i2c
+	go get github.com/eclipse/paho.mqtt.golang
 
 ##### build SmartPi tools
 	cd  ~/SmartPi


### PR DESCRIPTION
I had this issue:

pi@raspberrypi:~/SmartPi $ make
start building tree...
start building smartpireadout...
GOPATH=/home/pi/SmartPi /usr/local/go/bin/go build -o bin/smartpireadout src/main/readout.go
src/main/readout.go:41:3: cannot find package "github.com/eclipse/paho.mqtt.golang" in any of:
        /usr/local/go/src/github.com/eclipse/paho.mqtt.golang (from $GOROOT)
        /home/pi/SmartPi/src/github.com/eclipse/paho.mqtt.golang (from $GOPATH)
makefile:28: recipe for target 'buildsmartpireadout' failed
make: *** [buildsmartpireadout] Error 1

because "paho.mqtt.golang" was missing, so I have added the library as dependency
