### PR TITLE
Refactor ADE7878 reader functions

### DIFF
--- a/src/smartpi/ade7878.go
+++ b/src/smartpi/ade7878.go
@@ -27,6 +27,7 @@
 package smartpi
 
 import (
+	"encoding/binary"
 	"fmt"
 	"github.com/nathan-osman/go-rpigpio"
 	"golang.org/x/exp/io/i2c"
@@ -35,9 +36,9 @@ import (
 )
 
 const (
-	I2C_DEVICE                        = "/dev/i2c-1"
-	ADE7878_ADDR                      = 0x38
-	SAMPLES                           = 100
+	I2C_DEVICE                string  = "/dev/i2c-1"
+	ADE7878_ADDR              int     = 0x38
+	SAMPLES                   int     = 100
 	ADE7878_CLOCK             float32 = 256000
 	FACTOR_CIRCLE             float32 = 360
 	VAL                       float32 = math.Pi / 180.0
@@ -68,6 +69,32 @@ const (
 var (
 	rms_factor_current float32
 )
+
+// Fetch a number of bytes from the device and convert it to an int.
+func DeviceFetchInt(d *i2c.Device, l int, cmd []byte) int64 {
+	err := d.Write(cmd)
+	if err != nil {
+		panic(err)
+	}
+	data := make([]byte, l)
+	err = d.Read(data)
+	if err != nil {
+		panic(err)
+	}
+	var result int64
+	switch l {
+	case 8:
+		result = int64(binary.BigEndian.Uint64(data))
+	case 4:
+		result = int64(int32(binary.BigEndian.Uint32(data)))
+	case 2:
+		result = int64(int16(binary.BigEndian.Uint16(data)))
+	default:
+		panic(fmt.Errorf("Invalid byte length for int conversion %d", l))
+	}
+	// fmt.Printf("DeviceFetchInt: cmd: %x data: %x result: %d\n", cmd, data, result)
+	return result
+}
 
 func resetADE7878() {
 	println("RESET")
@@ -265,15 +292,9 @@ func InitADE7878(c *Config) (*i2c.Device, error) {
 }
 
 func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
-
-	var dataAddress []byte
-	var data []byte
 	var values [25]float32
 	var outcome float32
 	var err error
-
-	initPiForADE7878()
-	//resetADE7878()
 
 	if c.Powerfrequency == 60 {
 		rms_factor_current = float32(3493258) // 60Hz
@@ -281,381 +302,265 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		rms_factor_current = float32(4191910) // 50Hz
 	}
 
-	dataAddress = make([]byte, 2)
-
 	voltage_measure_1 := true
 	voltage_measure_2 := true
 	voltage_measure_3 := true
 
-	for i := 0; i <= 24; i++ {
-
-		switch i {
-
-		case 0:
-			// Current phase A (amps).
-			dataAddress[0] = 0x43 // 0x43C0 (AIRMS; Current rms an A)
-			dataAddress[1] = 0xC0
-			data = make([]byte, 4)
-		case 1:
-			// Current phase B (amps).
-			dataAddress[0] = 0x43 // 0x43C2 (BIRMS; Current rms an B)
-			dataAddress[1] = 0xC2
-			data = make([]byte, 4)
-		case 2:
-			// Current phase C (amps).
-			dataAddress[0] = 0x43 // 0x43C4 (CIRMS; Current rms an C)
-			dataAddress[1] = 0xC4
-			data = make([]byte, 4)
-		case 3:
-			// Current Neutral (amps)
-			dataAddress[0] = 0x43 // 0x43C6 (NIRMS; Current rms neutral conductor)
-			dataAddress[1] = 0xC6
-			data = make([]byte, 4)
-		case 4:
-			// Voltage phase A (volts)
-			dataAddress[0] = 0x43 // 0x43C1 (AVRMS; Voltage rms an A)
-			dataAddress[1] = 0xC1
-			data = make([]byte, 4)
-		case 5:
-			// Voltage phase B (volts)
-			dataAddress[0] = 0x43 // 0x43C3 (BVRMS; Voltage rms an B)
-			dataAddress[1] = 0xC3
-			data = make([]byte, 4)
-		case 6:
-			// Voltage phase C (volts)
-			dataAddress[0] = 0x43 // 0x43C5 (CVRMS; Voltage rms an C)
-			dataAddress[1] = 0xC5
-			data = make([]byte, 4)
-		case 7:
-			// Total active power phase A (watts).
-			dataAddress[0] = 0xE5 // 0xE513 (AWATT total active power an A)
-			dataAddress[1] = 0x13
-			data = make([]byte, 4)
-		case 8:
-			// Total active power phase A (watts).
-			dataAddress[0] = 0xE5 // 0xE514 (BWATT total active power an B)
-			dataAddress[1] = 0x14
-			data = make([]byte, 4)
-		case 9:
-			// Total active power phase A (watts).
-			dataAddress[0] = 0xE5 // 0xE515 (CWATT total active power an C)
-			dataAddress[1] = 0x15
-			data = make([]byte, 4)
-		case 10:
-			// Cosphi phase A
-			dataAddress[0] = 0xE6 // 0xE601 (ANGLE0 cosphi an A)
-			dataAddress[1] = 0x01
-			data = make([]byte, 2)
-		case 11:
-			// Cosphi phase B
-			dataAddress[0] = 0xE6 // 0xE602 (ANGLE1 cosphi an B)
-			dataAddress[1] = 0x02
-			data = make([]byte, 2)
-		case 12:
-			// Cosphi phase C
-			dataAddress[0] = 0xE6 // 0xE603 (ANGLE1 cosphi an B)
-			dataAddress[1] = 0x03
-			data = make([]byte, 2)
-		case 13:
-			// Frequency phase A (hertz).
-			register := []byte{0xE7, 0x00, 0x1C} // MMODE-Register measure frequency at VA
-			err := d.Write(register)
-			if err != nil {
-				panic(err)
-			}
-			time.Sleep(50 * time.Millisecond)
-			dataAddress[0] = 0xE6 // 0xE607 (PERIOD)
-			dataAddress[1] = 0x07
-			data = make([]byte, 2)
-		case 14:
-			// Frequency phase B (hertz).
-			register := []byte{0xE7, 0x00, 0x1D} // MMODE-Register measure frequency at VB
-			err = d.Write(register)
-			if err != nil {
-				panic(err)
-			}
-			time.Sleep(50 * time.Millisecond)
-			dataAddress[0] = 0xE6 // 0xE607 (PERIOD)
-			dataAddress[1] = 0x07
-			data = make([]byte, 2)
-		case 15:
-			// Frequency phase C (hertz).
-			register := []byte{0xE7, 0x00, 0x1E} // MMODE-Register measure frequency at VC
-			err = d.Write(register)
-			if err != nil {
-				panic(err)
-			}
-			time.Sleep(50 * time.Millisecond)
-			dataAddress[0] = 0xE6 // 0xE607 (PERIOD)
-			dataAddress[1] = 0x07
-			data = make([]byte, 2)
-		case 16:
-			// Total apparent power phase A (volt-amps).
-			dataAddress[0] = 0xE5 // 0xE519 (AVA total apparent power an A)
-			dataAddress[1] = 0x19
-			data = make([]byte, 4)
-		case 17:
-			// Total apparent power phase B (volt-amps).
-			dataAddress[0] = 0xE5 // 0xE51A (BVA total apparent power an B)
-			dataAddress[1] = 0x1A
-			data = make([]byte, 4)
-		case 18:
-			// Total apparent power phase C (volt-amps).
-			dataAddress[0] = 0xE5 // 0xE51B (CVA total apparent power an C)
-			dataAddress[1] = 0x1B
-			data = make([]byte, 4)
-		case 19:
-			// Total reactive power phase A (volt-ampere reactive).
-			dataAddress[0] = 0xE5 // 0xE516 (AVAR total reactive power an A)
-			dataAddress[1] = 0x16
-			data = make([]byte, 4)
-		case 20:
-			// Total reactive power phase B (volt-ampere reactive).
-			dataAddress[0] = 0xE5 // 0xE517 (BVAR total reactive power an B)
-			dataAddress[1] = 0x17
-			data = make([]byte, 4)
-		case 21:
-			// Total reactive power phase C (volt-ampere reactive).
-			dataAddress[0] = 0xE5 // 0xE518 (CVAR total reactive power an C)
-			dataAddress[1] = 0x18
-			data = make([]byte, 4)
-		}
-
-		// for j:=0; j<SAMPLES; j++ {
-
-		err = d.Write(dataAddress)
-		if err != nil {
-			panic(err)
-		}
-		err = d.Read(data)
-		if err != nil {
-			panic(err)
-		}
-
-		switch i {
-		case 0, 1, 2, 3, 4, 5, 6:
-			// outcome = outcome + float32(FACTOR_3*int(data[0])+FACTOR_2*int(data[1])+FACTOR_1*int(data[2])+int(data[3]))
-			outcome = float32(FACTOR_2*int(data[1]) + FACTOR_1*int(data[2]) + int(data[3]))
-			fmt.Printf("I: %d, Data0: %x, Data1: %x, Data2: %x, Data3: %x \n", i, data[0], data[1], data[2], data[3])
-		case 10, 11, 12, 13, 14, 15:
-			// outcome = outcome + float32(FACTOR_1*int(data[0])+int(data[1]))
-			outcome = float32(FACTOR_1*int(data[0]) + int(data[1]))
-		case 7, 8, 9, 16, 17, 18, 19, 20, 21:
-			// outcome = outcome + float32(FACTOR_3*int(data[0])+FACTOR_2*int(data[1])+FACTOR_1*int(data[2])+int(data[3]))
-			outcome = float32(FACTOR_3*int(data[0]) + FACTOR_2*int(data[1]) + FACTOR_1*int(data[2]) + int(data[3]))
-		}
-
-		// }
-
-		// outcome = outcome / float32(SAMPLES)
-
-		switch i {
-		case 0:
-			if c.MeasureCurrent1 == 1 {
-				values[0] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_A) / CURRENT_CLAMP_FACTOR_A) * 100.0 * OFFSET_CURRENT_A
-			} else {
-				values[0] = 0.0
-			}
-		case 1:
-			if c.MeasureCurrent2 == 1 {
-				values[1] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_B) / CURRENT_CLAMP_FACTOR_B) * 100.0 * OFFSET_CURRENT_B
-			} else {
-				values[1] = 0.0
-			}
-		case 2:
-			if c.MeasureCurrent3 == 1 {
-				values[2] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_C) / CURRENT_CLAMP_FACTOR_C) * 100.0 * OFFSET_CURRENT_C
-			} else {
-				values[2] = 0.0
-			}
-		case 3:
-			values[3] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_N) / CURRENT_CLAMP_FACTOR_N) * 100.0 * OFFSET_CURRENT_N
-		case 4:
-			values[4] = float32(float32(outcome) / 1e+4)
-			voltage_measure_1 = true
-			if c.MeasureVoltage1 == 0 || values[4] < 10 {
-				values[4] = float32(c.Voltage1)
-				voltage_measure_1 = false
-			}
-		case 5:
-			values[5] = float32(float32(outcome) / 1e+4)
-			voltage_measure_2 = true
-			if c.MeasureVoltage2 == 0 || values[5] < 10 {
-				values[5] = float32(c.Voltage2)
-				voltage_measure_2 = false
-			}
-
-		case 6:
-			values[6] = float32(float32(outcome) / 1e+4)
-			voltage_measure_3 = true
-			if c.MeasureVoltage3 == 0 || values[6] < 10 {
-				values[6] = float32(c.Voltage3)
-				voltage_measure_3 = false
-			}
-
-		case 7:
-			if c.MeasureCurrent1 == 1 {
-				values[i] = float32(outcome * POWER_CORRECTION_FACTOR_A)
-			} else {
-				values[i] = 0.0
-			}
-
-			if c.Currentdirection1 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if !voltage_measure_1 {
-				values[7] = values[0] * values[4]
-			}
-
-		case 8:
-			if c.MeasureCurrent2 == 1 {
-				values[i] = float32(outcome * POWER_CORRECTION_FACTOR_B)
-			} else {
-				values[i] = 0.0
-			}
-
-			if c.Currentdirection2 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if !voltage_measure_2 {
-				values[8] = values[1] * values[5]
-			}
-
-		case 9:
-			if c.MeasureCurrent3 == 1 {
-				values[i] = float32(outcome * POWER_CORRECTION_FACTOR_C)
-			} else {
-				values[i] = 0.0
-			}
-
-			if c.Currentdirection3 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if !voltage_measure_3 {
-				values[9] = values[2] * values[6]
-			}
-
-		case 10:
-			values[10] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
-
-			if c.Currentdirection1 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if c.MeasureVoltage1 == 0 {
-				values[10] = 1.0
-			}
-
-		case 11:
-			values[11] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
-
-			if c.Currentdirection2 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if c.MeasureVoltage2 == 0 {
-				values[11] = 1.0
-			}
-
-		case 12:
-			values[12] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
-
-			if c.Currentdirection3 == 1 {
-				values[i] = values[i] * -1
-			}
-
-			if c.MeasureVoltage3 == 0 {
-				values[12] = 1.0
-			}
-
-		case 13, 14, 15:
-			values[i] = float32(ADE7878_CLOCK / (outcome + 1))
-		case 16:
-			if c.MeasureCurrent1 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-		case 17:
-			if c.MeasureCurrent2 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-		case 18:
-			if c.MeasureCurrent3 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-		case 19:
-			if c.MeasureCurrent1 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-			if c.Currentdirection1 == 1 {
-				values[i] = values[i] * -1
-			}
-		case 20:
-			if c.MeasureCurrent2 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-			if c.Currentdirection2 == 1 {
-				values[i] = values[i] * -1
-			}
-		case 21:
-			if c.MeasureCurrent3 == 1 {
-				values[i] = float32(outcome)
-			} else {
-				values[i] = 0.0
-			}
-			if c.Currentdirection3 == 1 {
-				values[i] = values[i] * -1
-			}
-		case 22:
-			// ??????????????????????????????????????
-			if math.Signbit(float64(values[19])) {
-				values[i] = (values[7] / POWER_CORRECTION_FACTOR_A / values[16])
-			} else {
-				values[i] = -1 * (values[7] / POWER_CORRECTION_FACTOR_A / values[16])
-			}
-			if c.MeasureCurrent1 == 0 {
-				values[i] = 0.0
-			}
-		case 23:
-			if math.Signbit(float64(values[20])) {
-				values[i] = (values[8] / POWER_CORRECTION_FACTOR_B / values[17])
-			} else {
-				values[i] = -1 * (values[8] / POWER_CORRECTION_FACTOR_B / values[17])
-			}
-			if c.MeasureCurrent1 == 0 {
-				values[i] = 0.0
-			}
-		case 24:
-			if math.Signbit(float64(values[21])) {
-				values[i] = (values[9] / POWER_CORRECTION_FACTOR_C / values[18])
-			} else {
-				values[i] = -1 * (values[9] / POWER_CORRECTION_FACTOR_C / values[18])
-			}
-			if c.MeasureCurrent1 == 0 {
-				values[i] = 0.0
-			}
-		}
-
+	// Current phase A (amps).
+	if c.MeasureCurrent1 == 1 {
+		// 0x43C0 (AIRMS; Current rms an A)
+		outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC0}))
+		values[0] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_A) / CURRENT_CLAMP_FACTOR_A) * 100.0 * OFFSET_CURRENT_A
+	} else {
+		values[0] = 0.0
 	}
+
+	// Current phase B (amps).
+	if c.MeasureCurrent2 == 1 {
+		// 0x43C2 (BIRMS; Current rms an B)
+		outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC2}))
+		values[1] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_B) / CURRENT_CLAMP_FACTOR_B) * 100.0 * OFFSET_CURRENT_B
+	} else {
+		values[1] = 0.0
+	}
+
+	// Current phase C (amps).
+	if c.MeasureCurrent3 == 1 {
+		// 0x43C4 (CIRMS; Current rms an C)
+		outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC4}))
+		values[2] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_C) / CURRENT_CLAMP_FACTOR_C) * 100.0 * OFFSET_CURRENT_C
+	} else {
+		values[2] = 0.0
+	}
+
+	// Current Neutral (amps)
+	// 0x43C6 (NIRMS; Current rms neutral conductor)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC6}))
+	values[3] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_N) / CURRENT_CLAMP_FACTOR_N) * 100.0 * OFFSET_CURRENT_N
+
+	// Voltage phase A (volts)
+	// 0x43C1 (AVRMS; Voltage rms an A)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC1}))
+	values[4] = float32(outcome / 1e+4)
+	voltage_measure_1 = true
+	if c.MeasureVoltage1 == 0 || values[4] < 10 {
+		values[4] = float32(c.Voltage1)
+		voltage_measure_1 = false
+	}
+
+	// Voltage phase B (volts)
+	// 0x43C3 (BVRMS; Voltage rms an B)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC3}))
+	values[5] = float32(outcome / 1e+4)
+	voltage_measure_2 = true
+	if c.MeasureVoltage2 == 0 || values[5] < 10 {
+		values[5] = float32(c.Voltage2)
+		voltage_measure_2 = false
+	}
+
+	// Voltage phase C (volts)
+	// 0x43C5 (BVRMS; Voltage rms an C)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0x43, 0xC5}))
+	values[6] = float32(outcome / 1e+4)
+	voltage_measure_3 = true
+	if c.MeasureVoltage3 == 0 || values[6] < 10 {
+		values[6] = float32(c.Voltage3)
+		voltage_measure_3 = false
+	}
+
+	// Total active power phase A (watts).
+	// 0xE513 (AWATT total active power an A)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x13}))
+	if c.MeasureCurrent1 == 1 {
+		values[7] = float32(outcome * POWER_CORRECTION_FACTOR_A)
+	} else {
+		values[7] = 0.0
+	}
+	if c.Currentdirection1 == 1 {
+		values[7] = values[7] * -1
+	}
+	if !voltage_measure_1 {
+		values[7] = values[0] * values[4]
+	}
+
+	// Total active power phase B (watts).
+	// 0xE514 (AWATT total active power an B)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x14}))
+	if c.MeasureCurrent2 == 1 {
+		values[8] = float32(outcome * POWER_CORRECTION_FACTOR_B)
+	} else {
+		values[8] = 0.0
+	}
+	if c.Currentdirection2 == 1 {
+		values[8] = values[8] * -1
+	}
+	if !voltage_measure_2 {
+		values[8] = values[1] * values[5]
+	}
+
+	// Total active power phase C (watts).
+	// 0xE515 (AWATT total active power an C)
+	outcome = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x15}))
+	if c.MeasureCurrent3 == 1 {
+		values[9] = float32(outcome * POWER_CORRECTION_FACTOR_C)
+	} else {
+		values[9] = 0.0
+	}
+	if c.Currentdirection3 == 1 {
+		values[9] = values[9] * -1
+	}
+	if !voltage_measure_3 {
+		values[9] = values[2] * values[6]
+	}
+
+	// 0xE601 (ANGLE0 cosphi an A)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x01}))
+	values[10] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
+	if c.Currentdirection1 == 1 {
+		values[10] = values[10] * -1
+	}
+	if c.MeasureVoltage1 == 0 {
+		values[10] = 1.0
+	}
+
+	// 0xE602 (ANGLE1 cosphi an B)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x02}))
+	values[11] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
+	if c.Currentdirection2 == 1 {
+		values[11] = values[11] * -1
+	}
+	if c.MeasureVoltage2 == 0 {
+		values[11] = 1.0
+	}
+
+	// 0xE603 (ANGLE1 cosphi an C)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x03}))
+	values[12] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
+	if c.Currentdirection3 == 1 {
+		values[12] = values[12] * -1
+	}
+	if c.MeasureVoltage3 == 0 {
+		values[12] = 1.0
+	}
+
+	err = d.Write([]byte{0xE7, 0x00, 0x1C}) // MMODE-Register measure frequency at VA
+	if err != nil {
+		panic(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	// 0xE607 (PERIOD)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x07}))
+	values[13] = float32(ADE7878_CLOCK / (outcome + 1))
+
+	err = d.Write([]byte{0xE7, 0x00, 0x1D}) // MMODE-Register measure frequency at VB
+	if err != nil {
+		panic(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	// 0xE607 (PERIOD)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x07}))
+	values[14] = float32(ADE7878_CLOCK / (outcome + 1))
+
+	err = d.Write([]byte{0xE7, 0x00, 0x1E}) // MMODE-Register measure frequency at VC
+	if err != nil {
+		panic(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	// 0xE607 (PERIOD)
+	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x07}))
+	values[15] = float32(ADE7878_CLOCK / (outcome + 1))
+
+	// Total apparent power phase A (volt-amps).
+	if c.MeasureCurrent1 == 1 {
+		// 0xE519 (AVA total apparent power an A)
+		values[16] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x19}))
+	} else {
+		values[16] = 0.0
+	}
+
+	// Total apparent power phase B (volt-amps).
+	if c.MeasureCurrent2 == 1 {
+		// 0xE51A (BVA total apparent power an B)
+		values[17] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x1A}))
+	} else {
+		values[17] = 0.0
+	}
+
+	// Total apparent power phase A (volt-amps).
+	if c.MeasureCurrent3 == 1 {
+		// 0xE51B (CVA total apparent power an C)
+		values[18] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x1B}))
+	} else {
+		values[18] = 0.0
+	}
+
+	// Total reactive power phase A (volt-ampere reactive).
+	if c.MeasureCurrent1 == 1 {
+		// 0xE516 (AVAR total reactive power an A)
+		values[19] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x16}))
+	} else {
+		values[19] = 0.0
+	}
+	if c.Currentdirection1 == 1 {
+		values[19] = values[19] * -1
+	}
+
+	// Total reactive power phase B (volt-ampere reactive).
+	if c.MeasureCurrent2 == 1 {
+		// 0xE517 (BVAR total reactive power an B)
+		values[20] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x17}))
+	} else {
+		values[20] = 0.0
+	}
+	if c.Currentdirection2 == 1 {
+		values[20] = values[20] * -1
+	}
+
+	// Total reactive power phase C (volt-ampere reactive).
+	if c.MeasureCurrent3 == 1 {
+		// 0xE518 (CVAR total reactive power an C)
+		values[21] = float32(DeviceFetchInt(d, 4, []byte{0xE5, 0x18}))
+	} else {
+		values[21] = 0.0
+	}
+	if c.Currentdirection3 == 1 {
+		values[21] = values[21] * -1
+	}
+
+	if math.Signbit(float64(values[19])) {
+		values[22] = (values[7] / POWER_CORRECTION_FACTOR_A / values[16])
+	} else {
+		values[22] = -1 * (values[7] / POWER_CORRECTION_FACTOR_A / values[16])
+	}
+	if c.MeasureCurrent1 == 0 {
+		values[22] = 0.0
+	}
+
+	if math.Signbit(float64(values[20])) {
+		values[23] = (values[8] / POWER_CORRECTION_FACTOR_B / values[17])
+	} else {
+		values[23] = -1 * (values[8] / POWER_CORRECTION_FACTOR_B / values[17])
+	}
+	if c.MeasureCurrent2 == 0 {
+		values[23] = 0.0
+	}
+
+	if math.Signbit(float64(values[21])) {
+		values[24] = (values[9] / POWER_CORRECTION_FACTOR_C / values[18])
+	} else {
+		values[24] = -1 * (values[9] / POWER_CORRECTION_FACTOR_C / values[18])
+	}
+	if c.MeasureCurrent3 == 0 {
+		values[24] = 0.0
+	}
+
 	fmt.Printf("I1: %g  I2: %g  I3: %g  I4: %g  ", values[0], values[1], values[2], values[3])
 	fmt.Printf("V1: %g  V2: %g  V3: %g  ", values[4], values[5], values[6])
 	fmt.Printf("P1: %g  P2: %g  P3: %g  ", values[7], values[8], values[9])
 	fmt.Printf("COS1: %g  COS2: %g  COS3: %g  ", values[10], values[11], values[12])
 	fmt.Printf("F1: %g  F2: %g  F3: %g  ", values[13], values[14], values[15])
 	fmt.Printf("AVA: %g  BVA: %g  CVA: %g  ", values[16], values[17], values[18])
-	fmt.Printf("AVAR: %g  BVAR: %g  CVAR: %g  ", values[20], values[20], values[21])
+	fmt.Printf("AVAR: %g  BVAR: %g  CVAR: %g  ", values[19], values[20], values[21])
 	fmt.Printf("PFA: %g  PFB: %g  PFC: %g  ", values[22], values[23], values[24])
 	fmt.Printf("\n")
 

--- a/src/smartpi/ade7878.go
+++ b/src/smartpi/ade7878.go
@@ -92,201 +92,114 @@ func initPiForADE7878() {
 }
 
 func InitADE7878(c *Config) (*i2c.Device, error) {
-
-	var dataAddress []byte
-	dataAddress = make([]byte, 3)
-	var i2cLock []byte
-	i2cLock = make([]byte, 1)
-
 	d, err := i2c.Open(&i2c.Devfs{Dev: I2C_DEVICE}, ADE7878_ADDR)
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress[0] = 0xEC //0xEC01 (CONFIG2-REGISTER)
-	dataAddress[1] = 0x01
-	dataAddress[2] = 0x02 //00000010 --> Bedeutet I2C-Lock (I2C ist nun die gewählte Übertragungsart)
-
-	err = d.Write(dataAddress)
+	// 0xEC01 (CONFIG2-REGISTER)
+	// 00000010 --> Bedeutet I2C-Lock (I2C ist nun die gewählte Übertragungsart)
+	err = d.Write([]byte{0xEC, 0x01, 0x02})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 1)
-	dataAddress[0] = 0xEC //0xEC01 (CONFIG2-REGISTER)
-
-	err = d.Write(dataAddress)
+	// 0xE1 (CONFIG2-REGISTER)
+	err = d.Write([]byte{0xEC})
 	if err != nil {
 		panic(err)
 	}
 
+	// Read i2cLock
+	i2cLock := make([]byte, 1)
 	err = d.Read(i2cLock)
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 3)
-	dataAddress[0] = 0xE7 //0xE7FE writeprotection
-	dataAddress[1] = 0xFE
-	dataAddress[2] = 0xAD
-
-	err = d.Write(dataAddress)
-	if err != nil {
-		panic(err)
-	}
-	dataAddress[0] = 0xE7 //0xE7E3 writeprotection OFF
-	dataAddress[1] = 0xE3
-	dataAddress[2] = 0x00
-
-	err = d.Write(dataAddress)
+	// 0xE7FE writeprotection
+	err = d.Write([]byte{0xE7, 0xFE, 0xAD})
 	if err != nil {
 		panic(err)
 	}
 
-	// dataAddress = make([]byte, 6)
-	// dataAddress[0] = 0x43;//0x43B6 (HPFDIS-REGISTER)
-	// dataAddress[1] = 0xB6;
-	// dataAddress[2] = 0x00;
-	// dataAddress[3] = 0x00;
-	// dataAddress[4] = 0x00;
-	// dataAddress[5] = 0x00;
-	//
-	// err = d.Write(dataAddress)
+	// 0xE7E3 writeprotection OFF
+	err = d.Write([]byte{0xE7, 0xE3, 0x00})
+	if err != nil {
+		panic(err)
+	}
+
+	// // 0x43B6 (HPFDIS-REGISTER)
+	// err = d.Write([]byte{0x43, 0xB6, 0x00, 0x00, 0x00, 0x00})
 	// if err != nil {
 	//     panic(err)
 	// }
 
-	// set the right power frequency to the COMPMODE-REGISTER
-	dataAddress = make([]byte, 4)
-	dataAddress[0] = 0xE6 //0xE60E (COMPMODE-REGISTER)
-	dataAddress[1] = 0x0E
+	// Set the right power frequency to the COMPMODE-REGISTER.
+	// 0xE60E (COMPMODE-REGISTER)
 	if c.Powerfrequency == 60 {
-		dataAddress[2] = 0x41
-		dataAddress[3] = 0xFF
+		// 0x41FF 60Hz
+		err = d.Write([]byte{0xE6, 0x0E, 0x41, 0xFF})
 	} else {
-		dataAddress[2] = 0x01
-		dataAddress[3] = 0xFF
+		// 0x01FF 50Hz
+		err = d.Write([]byte{0xE6, 0x0E, 0x01, 0xFF})
 	}
-	err = d.Write(dataAddress)
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 5)
-	dataAddress[0] = 0x43 //0x43B5 (DICOEFF-REGISTER)
-	dataAddress[1] = 0xB5
-	dataAddress[2] = 0xFF
-	dataAddress[3] = 0x80
-	dataAddress[4] = 0x00
-
-	err = d.Write(dataAddress)
+	// 0x43B5 (DICOEFF-REGISTER)
+	err = d.Write([]byte{0x43, 0xB5, 0xFF, 0x80, 0x00})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x43AB (WTHR1-REGISTER)
-	dataAddress[1] = 0xAB
-	dataAddress[2] = 0x00
-	dataAddress[3] = 0x00
-	dataAddress[4] = 0x00
-	dataAddress[5] = 0x17
-
-	err = d.Write(dataAddress)
+	//0x43AB (WTHR1-REGISTER)
+	err = d.Write([]byte{0x43, 0xAB, 0x00, 0x00, 0x00, 0x17})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x43AC (WTHR0-REGISTER)
-	dataAddress[1] = 0xAC
-	dataAddress[2] = 0x00
-	dataAddress[3] = 0x85
-	dataAddress[4] = 0x60
-	dataAddress[5] = 0x16
-
-	err = d.Write(dataAddress)
+	//0x43AC (WTHR0-REGISTER)
+	err = d.Write([]byte{0x43, 0xAC, 0x00, 0x85, 0x60, 0x16})
 	if err != nil {
 		panic(err)
 	}
-	//
-	// dataAddress = make([]byte, 6)
-	// dataAddress[0] = 0x43;//0x43AD (VARTHR1-REGISTER)
-	// dataAddress[1] = 0xAD;
-	// dataAddress[2] = 0x17;
-	// dataAddress[3] = 0x85;
-	// dataAddress[4] = 0x60;
-	// dataAddress[5] = 0x16;
-	//
-	//
-	// err = d.Write(dataAddress)
+
+	// // 0x43AD (VARTHR1-REGISTER)
+	// err = d.Write([]byte{0x43, 0xAD, 0x17, 0x85, 0x60, 0x16})
 	// if err != nil {
 	//     panic(err)
 	// }
 	//
-	// dataAddress = make([]byte, 6)
-	// dataAddress[0] = 0x43;//0x43AE (VARTHR0-REGISTER)
-	// dataAddress[1] = 0xAE;
-	// dataAddress[2] = 0x17;
-	// dataAddress[3] = 0x85;
-	// dataAddress[4] = 0x60;
-	// dataAddress[5] = 0x16;
-	//
-	//
-	// err = d.Write(dataAddress)
+	// // 0x43AE (VARTHR0-REGISTER)
+	// err = d.Write([]byte{0x43, 0xAE, 0x17, 0x85, 0x60, 0x16})
 	// if err != nil {
 	//     panic(err)
 	// }
 	//
-	// dataAddress = make([]byte, 6)
-	// dataAddress[0] = 0x43;//0x43A9 (VATHR1-REGISTER)
-	// dataAddress[1] = 0xA9;
-	// dataAddress[2] = 0x17;
-	// dataAddress[3] = 0x85;
-	// dataAddress[4] = 0x60;
-	// dataAddress[5] = 0x16;
-	//
-	//
-	// err = d.Write(dataAddress)
+	// // 0x43A9 (VATHR1-REGISTER)
+	// err = d.Write([]byte{0x43, 0xA9, 0x17, 0x85, 0x60, 0x16})
 	// if err != nil {
 	//     panic(err)
 	// }
 	//
-	// dataAddress = make([]byte, 6)
-	// dataAddress[0] = 0x43;//0x43AA (VARTHR0-REGISTER)
-	// dataAddress[1] = 0xAA;
-	// dataAddress[2] = 0x17;
-	// dataAddress[3] = 0x85;
-	// dataAddress[4] = 0x60;
-	// dataAddress[5] = 0x16;
-	//
-	//
-	// err = d.Write(dataAddress)
+	// // 0x43AA (VARTHR0-REGISTER)
+	// err = d.Write([]byte{0x43, 0xAA, 0x17, 0x85, 0x60, 0x16})
 	// if err != nil {
 	//     panic(err)
 	// }
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x43B3 (VLEVEL-REGISTER)
-	dataAddress[1] = 0xB3
-	dataAddress[2] = 0x00
-	dataAddress[3] = 0x0C
-	dataAddress[4] = 0xEC
-	dataAddress[5] = 0x85
-
-	err = d.Write(dataAddress)
+	// 0x43B3 (VLEVEL-REGISTER)
+	err = d.Write([]byte{0x43, 0xB3, 0x00, 0x0C, 0xEC, 0x85})
 	if err != nil {
 		panic(err)
 	}
 
 	time.Sleep(875 * time.Millisecond)
 
-	// dataAddress = make([]byte, 2)
-	// dataAddress[0] = 0x43;//0x4381 (AVGAIN-REGISTER)
-	// dataAddress[1] = 0x81;
-	// data = make([]byte, 4)
-	//
-	// err = d.Write(dataAddress)
+	// // 0x4381 (AVGAIN-REGISTER)
+	// err = d.Write([]byte{0x43, 0x81})
 	// if err != nil {
 	// 		panic(err)
 	// }
@@ -298,95 +211,56 @@ func InitADE7878(c *Config) (*i2c.Device, error) {
 	// outcome = float32(FACTOR_3*int(data[0])+FACTOR_2*int(data[1])+FACTOR_1*int(data[2])+int(data[3]))
 	// fmt.Printf("AVGAIN-REGISTER VORHER%g   %x %x %x %x \n", outcome, data[0], data[1], data[2], data[3])
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x4381 (AVGAIN-REGISTER)
-	dataAddress[1] = 0x81
-	dataAddress[2] = 0xFF
-	dataAddress[3] = 0xFC
-	dataAddress[4] = 0x1C
-	dataAddress[5] = 0xC2
-
-	err = d.Write(dataAddress)
+	// 0x4381 (AVGAIN-REGISTER)
+	err = d.Write([]byte{0x43, 0x81, 0xFF, 0xFC, 0x1C, 0xC2})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x4383 (BVGAIN-REGISTER)
-	dataAddress[1] = 0x83
-	dataAddress[2] = 0xFF
-	dataAddress[3] = 0xFB
-	dataAddress[4] = 0xCA
-	dataAddress[5] = 0x60
-
-	err = d.Write(dataAddress)
+	// 0x4383 (BVGAIN-REGISTER)
+	err = d.Write([]byte{0x43, 0x83, 0xFF, 0xFB, 0xCA, 0x60})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 6)
-	dataAddress[0] = 0x43 //0x4385 (CVGAIN-REGISTER)
-	dataAddress[1] = 0x85
-	dataAddress[2] = 0xFF
-	dataAddress[3] = 0xFC
-	dataAddress[4] = 0x12
-	dataAddress[5] = 0xDE
-
-	err = d.Write(dataAddress)
+	// 0x4385 (CVGAIN-REGISTER)
+	err = d.Write([]byte{0x43, 0x85, 0xFF, 0xFC, 0x12, 0xDE})
 	if err != nil {
 		panic(err)
 	}
 
 	// Line cycle mode
-	dataAddress = make([]byte, 3)
-	dataAddress[0] = 0xE7 //0xE702 LCYCMODE
-	dataAddress[1] = 0x02
-	dataAddress[2] = 0x0F
-
-	err = d.Write(dataAddress)
+	// 0xE702 LCYCMODE
+	err = d.Write([]byte{0xE7, 0x02, 0x0F})
 	if err != nil {
 		panic(err)
 	}
 
 	// Line cycle mode count
-	dataAddress = make([]byte, 3)
-	dataAddress[0] = 0xE6 //0xE60C LINECYC
-	dataAddress[1] = 0x0C
-	dataAddress[2] = 0xC8
-
-	err = d.Write(dataAddress)
+	// 0xE60C LINECYC
+	err = d.Write([]byte{0xE6, 0x0C, 0xC8})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 3)
-	dataAddress[0] = 0xE7 //0xE7FE writeprotection
-	dataAddress[1] = 0xFE
-	dataAddress[2] = 0xAD
-
-	err = d.Write(dataAddress)
-	if err != nil {
-		panic(err)
-	}
-	dataAddress[0] = 0xE7 //0xE7E3 writeprotection
-	dataAddress[1] = 0xE3
-	dataAddress[2] = 0x80
-
-	err = d.Write(dataAddress)
+	// 0xE7FE writeprotection
+	err = d.Write([]byte{0xE7, 0xFE, 0xAD})
 	if err != nil {
 		panic(err)
 	}
 
-	dataAddress = make([]byte, 4)
-	dataAddress[0] = 0xE2 //0xE228 (RUN-Register)
-	dataAddress[1] = 0x28
-	dataAddress[2] = 0x00
-	dataAddress[3] = 0x01
-
-	err = d.Write(dataAddress)
+	// 0xE7E3 writeprotection
+	err = d.Write([]byte{0xE7, 0xE3, 0x80})
 	if err != nil {
 		panic(err)
 	}
+
+	// 0xE228 (RUN-Register)
+	err = d.Write([]byte{0xE2, 0x28, 0x00, 0x01})
+	if err != nil {
+		panic(err)
+	}
+
 	return d, nil
 }
 
@@ -592,7 +466,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 			if c.MeasureCurrent3 == 1 {
 				values[2] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_C) / CURRENT_CLAMP_FACTOR_C) * 100.0 * OFFSET_CURRENT_C
 			} else {
-				 values[2] = 0.0
+				values[2] = 0.0
 			}
 		case 3:
 			values[3] = ((((outcome * 0.3535) / rms_factor_current) / CURRENT_RESISTOR_N) / CURRENT_CLAMP_FACTOR_N) * 100.0 * OFFSET_CURRENT_N

--- a/src/smartpi/ade7878.go
+++ b/src/smartpi/ade7878.go
@@ -42,9 +42,6 @@ const (
 	ADE7878_CLOCK             float32 = 256000
 	FACTOR_CIRCLE             float32 = 360
 	VAL                       float32 = math.Pi / 180.0
-	FACTOR_1                  int     = 256
-	FACTOR_2                  int     = 65536
-	FACTOR_3                  int     = 16777216
 	RMS_FACTOR_VOLTAGE        float32 = 2427873
 	CURRENT_RESISTOR_A        float32 = 7.07107
 	CURRENT_RESISTOR_B        float32 = 7.07107
@@ -226,16 +223,7 @@ func InitADE7878(c *Config) (*i2c.Device, error) {
 	time.Sleep(875 * time.Millisecond)
 
 	// // 0x4381 (AVGAIN-REGISTER)
-	// err = d.Write([]byte{0x43, 0x81})
-	// if err != nil {
-	// 		panic(err)
-	// }
-	// err = d.Read(data)
-	// if err != nil {
-	// 		panic(err)
-	// }
-	//
-	// outcome = float32(FACTOR_3*int(data[0])+FACTOR_2*int(data[1])+FACTOR_1*int(data[2])+int(data[3]))
+	// outcome := DeviceFetchInt(d, 4, []byte{0x43, 0x81})
 	// fmt.Printf("AVGAIN-REGISTER VORHER%g   %x %x %x %x \n", outcome, data[0], data[1], data[2], data[3])
 
 	// 0x4381 (AVGAIN-REGISTER)
@@ -377,7 +365,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[7] = 0.0
 	}
 	if c.Currentdirection1 == 1 {
-		values[7] = values[7] * -1
+		values[7] *= -1
 	}
 	if !voltage_measure_1 {
 		values[7] = values[0] * values[4]
@@ -392,7 +380,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[8] = 0.0
 	}
 	if c.Currentdirection2 == 1 {
-		values[8] = values[8] * -1
+		values[8] *= -1
 	}
 	if !voltage_measure_2 {
 		values[8] = values[1] * values[5]
@@ -407,7 +395,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[9] = 0.0
 	}
 	if c.Currentdirection3 == 1 {
-		values[9] = values[9] * -1
+		values[9] *= -1
 	}
 	if !voltage_measure_3 {
 		values[9] = values[2] * values[6]
@@ -417,7 +405,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x01}))
 	values[10] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
 	if c.Currentdirection1 == 1 {
-		values[10] = values[10] * -1
+		values[10] *= -1
 	}
 	if c.MeasureVoltage1 == 0 {
 		values[10] = 1.0
@@ -427,7 +415,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x02}))
 	values[11] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
 	if c.Currentdirection2 == 1 {
-		values[11] = values[11] * -1
+		values[11] *= -1
 	}
 	if c.MeasureVoltage2 == 0 {
 		values[11] = 1.0
@@ -437,7 +425,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 	outcome = float32(DeviceFetchInt(d, 2, []byte{0xE6, 0x03}))
 	values[12] = float32(math.Cos(float64(outcome * FACTOR_CIRCLE * float32(c.Powerfrequency) / ADE7878_CLOCK * VAL)))
 	if c.Currentdirection3 == 1 {
-		values[12] = values[12] * -1
+		values[12] *= -1
 	}
 	if c.MeasureVoltage3 == 0 {
 		values[12] = 1.0
@@ -502,7 +490,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[19] = 0.0
 	}
 	if c.Currentdirection1 == 1 {
-		values[19] = values[19] * -1
+		values[19] *= -1
 	}
 
 	// Total reactive power phase B (volt-ampere reactive).
@@ -513,7 +501,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[20] = 0.0
 	}
 	if c.Currentdirection2 == 1 {
-		values[20] = values[20] * -1
+		values[20] *= -1
 	}
 
 	// Total reactive power phase C (volt-ampere reactive).
@@ -524,7 +512,7 @@ func ReadoutValues(d *i2c.Device, c *Config) [25]float32 {
 		values[21] = 0.0
 	}
 	if c.Currentdirection3 == 1 {
-		values[21] = values[21] * -1
+		values[21] *= -1
 	}
 
 	if math.Signbit(float64(values[19])) {


### PR DESCRIPTION
Cleanup InitADE7878:
* Replace `dataAddress` variable use with literal byte slices.

Refactor ReadoutValues:
* Add new `DeviceFetchInt` function to handle device fetching and byte to int conversions.
* Get rid of case statements.

Other:
* Re-apply `go fmt`.
* Cleanup whitespace.
* Cleanup commented out code bits.