### PR TITLE
Speedup rebuilds.

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,8 +12,6 @@ GOINSTALL=$(GO) install
 GOCLEAN=$(GO) clean
 GOGET=$(GO) get
 
-export GOPATH=$(CURDIR)
-
 all: makedir get buildsmartpireadout buildsmartpiserver buildsmartpiftpupload
 #all: makedir get buildsmartpireadout 
 
@@ -26,17 +24,17 @@ get:
 
 buildsmartpireadout:
 	@echo "start building smartpireadout..."
-	GOPATH=$(BUILDPATH) $(GOBUILD) -o bin/$(BINARY_READOUT) src/main/readout.go
+	$(GOBUILD) -o bin/$(BINARY_READOUT) src/main/readout.go
 	@echo "building smartpireadout done"
 
 buildsmartpiserver:
 	@echo "start building smartpiserver..."
-	GOPATH=$(BUILDPATH) $(GOBUILD) -o bin/$(BINARY_SERVER) src/main/server.go
+	$(GOBUILD) -o bin/$(BINARY_SERVER) src/main/server.go
 	@echo "building smartpiserver done"
 
 buildsmartpiftpupload:
 	@echo "start building smartpiftpupload..."
-	GOPATH=$(BUILDPATH) $(GOBUILD) -o bin/$(BINARY_FTPUPLOAD) src/main/ftpupload.go
+	$(GOBUILD) -o bin/$(BINARY_FTPUPLOAD) src/main/ftpupload.go
 	@echo "building smartpiftpupload done"
 
 install:

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,14 @@ Download Raspbian Jessie Lite from https://www.raspberrypi.org/downloads/raspbia
 Alternatively, you may download EmonSD, a pre-built SD card image for Raspberry Pi running as an emonPi/emonBase
 Download https://github.com/openenergymonitor/emonpi/wiki/emonSD-pre-built-SD-card-Download-&-Change-Log
 
+##### Building source
+
+    go get -v github.com/nDenerserve/SmartPi/src/smartpi
+    cd ${GOPATH-$HOME/go}/src/github.com/nDenerserve/SmartPi
+    make
+
+NOTE: If you need to build from a fork, you will have to symlink your fork into `${GOPATH-$HOME/go}/src/github.com/nDenerserve/` to make golang dependencies work correctly.
+
 ##### Update packet list and update packages
 
     sudo apt-get update

--- a/src/github.com
+++ b/src/github.com
@@ -1,1 +1,0 @@
-../vendor/github.com/

--- a/src/golang.org
+++ b/src/golang.org
@@ -1,1 +1,0 @@
-../vendor/golang.org/

--- a/src/gopkg.in
+++ b/src/gopkg.in
@@ -1,1 +1,0 @@
-../vendor/gopkg.in/

--- a/src/main/ftpupload.go
+++ b/src/main/ftpupload.go
@@ -33,9 +33,10 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"smartpi"
 	"strings"
 	"time"
+
+	"github.com/nDenerserve/SmartPi/src/smartpi"
 )
 
 func main() {

--- a/src/main/readout.go
+++ b/src/main/readout.go
@@ -32,10 +32,11 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"smartpi"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nDenerserve/SmartPi/src/smartpi"
 
 	log "github.com/Sirupsen/logrus"
 	//import the Paho Go MQTT library

--- a/src/main/server.go
+++ b/src/main/server.go
@@ -33,8 +33,9 @@ import (
 	"golang.org/x/net/context"
 	"log"
 	"net/http"
-	"smartpi"
 	"strconv"
+
+	"github.com/nDenerserve/SmartPi/src/smartpi"
 )
 
 func stringInSlice(list1 []string, list2 []string) bool {


### PR DESCRIPTION
Update build instructions and makefile to speedup build process.

This reduces rebuild time on a Pi3 to under 20 seconds.

```
$ mkdir -p ${GOPATH}/src/github.com/nDenerserve
$ cd ${GOPATH}/src/github.com/nDenerserve
$ ln -s ~/src/superq/SmartPi/
$ git branch
* bjk/build
  master
$ cd SmartPi
$ go get -v github.com/nDenerserve/SmartPi/src/smartpi
github.com/nDenerserve/SmartPi/vendor/github.com/Sirupsen/logrus
github.com/nDenerserve/SmartPi/vendor/github.com/gorilla/mux
github.com/nDenerserve/SmartPi/vendor/golang.org/x/net/context
github.com/nDenerserve/SmartPi/vendor/github.com/nathan-osman/go-rpigpio
github.com/nDenerserve/SmartPi/vendor/github.com/mattn/go-sqlite3
github.com/nDenerserve/SmartPi/vendor/golang.org/x/exp/io/i2c/driver
github.com/nDenerserve/SmartPi/vendor/golang.org/x/exp/io/i2c
github.com/nDenerserve/SmartPi/vendor/gopkg.in/ini.v1
github.com/nDenerserve/SmartPi/src/smartpi
$ time make
start building tree...
start building smartpireadout...
/usr/local/go/bin/go build -o bin/smartpireadout src/main/readout.go
building smartpireadout done
start building smartpiserver...
/usr/local/go/bin/go build -o bin/smartpiserver src/main/server.go
building smartpiserver done
start building smartpiftpupload...
/usr/local/go/bin/go build -o bin/smartpiftpupload src/main/ftpupload.go
building smartpiftpupload done

real    0m18.844s
user    0m19.420s
sys     0m1.800s
```