### PR TITLE
Reduce readout server writes.

### DIFF
--- a/config/etc/smartpi
+++ b/config/etc/smartpi
@@ -10,13 +10,13 @@ lat=52.3667
 lng=9.7167
 
 [database]
+counter_enabled=true
 counterdir="/var/smartpi"
+database_enabled=true
 dir="/var/smartpi/db"
 
 [device]
 i2c_device="/dev/i2c-1"
-shared_dir="/var/tmp/smartpi"
-shared_file="values"
 power_frequency=50
 ct_type_1=YHDC_SCT013
 ct_type_2=YHDC_SCT013
@@ -47,6 +47,9 @@ decimalpoint=,
 timeformat=2006-01-02 15:04:05
 
 [webserver]
+shared_file_enabled=true
+shared_dir="/var/tmp/smartpi"
+shared_file="values"
 port=1080
 docroot="/var/smartpi/www"
 

--- a/config/etc/smartpi
+++ b/config/etc/smartpi
@@ -48,8 +48,8 @@ timeformat=2006-01-02 15:04:05
 
 [webserver]
 shared_file_enabled=true
-shared_dir="/var/tmp/smartpi"
-shared_file="values"
+shared_dir="/var/run"
+shared_file="smartpi_values"
 port=1080
 docroot="/var/smartpi/www"
 

--- a/src/readout/files.go
+++ b/src/readout/files.go
@@ -50,7 +50,6 @@ func writeSharedFile(c *smartpi.Config, values [25]float64) {
 	if err != nil {
 		panic(err)
 	}
-	f.Sync()
 	f.Close()
 }
 

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -66,7 +66,9 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			startTime := time.Now()
 			valuesr := smartpi.ReadoutValues(device, config)
 
-			writeSharedFile(config, valuesr)
+			if config.SharedFileEnabled {
+				writeSharedFile(config, valuesr)
+			}
 
 			// Publish readouts to MQTT.
 			if config.MQTTenabled {
@@ -112,11 +114,15 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 		}
 
 		// Update SQLlite database.
-		updateSQLiteDatabase(config, data)
+		if config.DatabaseEnabled {
+			updateSQLiteDatabase(config, data)
+		}
 
 		// Update persistent counter files.
-		updateCounterFile(config, consumerCounterFile, float64(data[16]+data[17]+data[18]))
-		updateCounterFile(config, producerCounterFile, float64(data[19]+data[20]+data[21]))
+		if config.CounterEnabled {
+			updateCounterFile(config, consumerCounterFile, float64(data[16]+data[17]+data[18]))
+			updateCounterFile(config, producerCounterFile, float64(data[19]+data[20]+data[21]))
+		}
 	}
 }
 

--- a/src/smartpi/config.go
+++ b/src/smartpi/config.go
@@ -46,13 +46,13 @@ type Config struct {
 	Lng float64
 
 	// [database]
-	CounterDir  string
-	DatabaseDir string
+	CounterEnabled  bool
+	CounterDir      string
+	DatabaseEnabled bool
+	DatabaseDir     string
 
 	// [device]
 	I2CDevice        string
-	SharedDir        string
-	SharedFile       string
 	PowerFrequency   float64
 	CTType           map[string]string
 	CurrentDirection map[string]bool
@@ -68,10 +68,15 @@ type Config struct {
 	FTPpath   string
 
 	// [webserver]
-	WebserverPort   int
-	DocRoot         string
-	CSVdecimalpoint string
-	CSVtimeformat   string
+	SharedFileEnabled bool
+	SharedDir         string
+	SharedFile        string
+	WebserverPort     int
+	DocRoot           string
+
+	// [csv]
+	CSVdecimalpoint   string
+	CSVtimeformat     string
 
 	// [mqtt]
 	MQTTenabled    bool
@@ -115,13 +120,13 @@ func (p *Config) ReadParameterFromFile() {
 	p.Lng = cfg.Section("location").Key("lng").MustFloat64(9.7167)
 
 	// [database]
+	p.CounterEnabled = cfg.Section("database").Key("counter_enabled").MustBool(true)
 	p.CounterDir = cfg.Section("database").Key("counterdir").MustString("/var/smartpi")
+	p.DatabaseEnabled = cfg.Section("database").Key("database_enabled").MustBool(true)
 	p.DatabaseDir = cfg.Section("database").Key("dir").MustString("/var/smartpi/db")
 
 	// [device]
 	p.I2CDevice = cfg.Section("device").Key("i2c_device").MustString("/dev/i2c-1")
-	p.SharedDir = cfg.Section("device").Key("shared_dir").MustString("/var/tmp/smartpi")
-	p.SharedFile = cfg.Section("device").Key("shared_file").MustString("values")
 	p.PowerFrequency = cfg.Section("device").Key("power_frequency").MustFloat64(50)
 	p.CTType = make(map[string]string)
 	p.CTType["A"] = cfg.Section("device").Key("ct_type_1").MustString("YHDC_SCT013")
@@ -154,8 +159,13 @@ func (p *Config) ReadParameterFromFile() {
 	p.FTPpath = cfg.Section("ftp").Key("ftp_path").String()
 
 	// [webserver]
+	p.SharedFileEnabled = cfg.Section("webserver").Key("shared_file_enabled").MustBool(true)
+	p.SharedDir = cfg.Section("webserver").Key("shared_dir").MustString("/var/tmp/smartpi")
+	p.SharedFile = cfg.Section("webserver").Key("shared_file").MustString("values")
 	p.WebserverPort = cfg.Section("webserver").Key("port").MustInt(1080)
 	p.DocRoot = cfg.Section("webserver").Key("docroot").MustString("/var/smartpi/www")
+
+	// [csv]
 	p.CSVdecimalpoint = cfg.Section("csv").Key("decimalpoint").String()
 	p.CSVtimeformat = cfg.Section("csv").Key("timeformat").String()
 
@@ -180,13 +190,13 @@ func (p *Config) SaveParameterToFile() {
 	_, err = cfg.Section("location").NewKey("lng", strconv.FormatFloat(p.Lng, 'f', -1, 64))
 
 	// [database]
+	_, err = cfg.Section("database").NewKey("counter_enabled", strconv.FormatBool(p.CounterEnabled))
 	_, err = cfg.Section("database").NewKey("counterdir", p.CounterDir)
+	_, err = cfg.Section("database").NewKey("database_enabled", strconv.FormatBool(p.DatabaseEnabled))
 	_, err = cfg.Section("database").NewKey("dir", p.DatabaseDir)
 
 	// [device]
 	_, err = cfg.Section("device").NewKey("i2c_device", p.I2CDevice)
-	_, err = cfg.Section("device").NewKey("shared_dir", p.SharedDir)
-	_, err = cfg.Section("device").NewKey("shared_file", p.SharedFile)
 	_, err = cfg.Section("device").NewKey("power_frequency", strconv.FormatInt(int64(p.PowerFrequency), 10))
 	_, err = cfg.Section("device").NewKey("ct_type_1", p.CTType["A"])
 	_, err = cfg.Section("device").NewKey("ct_type_2", p.CTType["B"])
@@ -217,8 +227,13 @@ func (p *Config) SaveParameterToFile() {
 	_, err = cfg.Section("ftp").NewKey("ftp_path", p.FTPpath)
 
 	// [webserver]
+	_, err = cfg.Section("webserver").NewKey("shared_file_enabled", strconv.FormatBool(p.SharedFileEnabled))
+	_, err = cfg.Section("webserver").NewKey("shared_dir", p.SharedDir)
+	_, err = cfg.Section("webserver").NewKey("shared_file", p.SharedFile)
 	_, err = cfg.Section("webserver").NewKey("port", strconv.FormatInt(int64(p.WebserverPort), 10))
 	_, err = cfg.Section("webserver").NewKey("docroot", p.DocRoot)
+
+	// [csv]
 	_, err = cfg.Section("csv").NewKey("decimalpoint", p.CSVdecimalpoint)
 	_, err = cfg.Section("csv").NewKey("timeformat", p.CSVtimeformat)
 

--- a/src/smartpi/config.go
+++ b/src/smartpi/config.go
@@ -160,8 +160,8 @@ func (p *Config) ReadParameterFromFile() {
 
 	// [webserver]
 	p.SharedFileEnabled = cfg.Section("webserver").Key("shared_file_enabled").MustBool(true)
-	p.SharedDir = cfg.Section("webserver").Key("shared_dir").MustString("/var/tmp/smartpi")
-	p.SharedFile = cfg.Section("webserver").Key("shared_file").MustString("values")
+	p.SharedDir = cfg.Section("webserver").Key("shared_dir").MustString("/var/run")
+	p.SharedFile = cfg.Section("webserver").Key("shared_file").MustString("smartpi_values")
 	p.WebserverPort = cfg.Section("webserver").Key("port").MustInt(1080)
 	p.DocRoot = cfg.Section("webserver").Key("docroot").MustString("/var/smartpi/www")
 


### PR DESCRIPTION
Add bool flags to enable/disable disk writing in the readout server
* Enable by default.
* Move shared dir/file flags to the webserver section.
* Update sample config.
* Separate `[cfg]` section in config.go.

Update default location for the shared readout file to `/var/run/smartpi_values` so that it is written to a ram tempfs.

Don't Sync() the shared file.