### PR TITLE
Add remaining readout values to Prometheus metrics

### DIFF
--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -138,6 +138,9 @@ func init() {
 	prometheus.MustRegister(activePowerMetirc)
 	prometheus.MustRegister(cosphiMetric)
 	prometheus.MustRegister(frequencyMetric)
+	prometheus.MustRegister(apparentPowerMetric)
+	prometheus.MustRegister(reactivePowerMetric)
+	prometheus.MustRegister(powerFactorMetric)
 	prometheus.MustRegister(version.NewCollector("smartpi"))
 }
 

--- a/src/readout/prometheus.go
+++ b/src/readout/prometheus.go
@@ -44,7 +44,7 @@ var (
 	frequencyMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
-			Name:      "phase_frequency_hertz",
+			Name:      "frequency_hertz",
 			Help:      "Line frequency in hertz",
 		},
 		[]string{"phase"},

--- a/src/readout/prometheus.go
+++ b/src/readout/prometheus.go
@@ -49,6 +49,30 @@ var (
 		},
 		[]string{"phase"},
 	)
+	apparentPowerMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "apparent_power_volt_amps",
+			Help:      "Line apparent power in volt amps",
+		},
+		[]string{"phase"},
+	)
+	reactivePowerMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "reactive_power_volt_amps",
+			Help:      "Line reactive power in volt amps reactive",
+		},
+		[]string{"phase"},
+	)
+	powerFactorMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "power_factor_ratio",
+			Help:      "Line power factor ratio",
+		},
+		[]string{"phase"},
+	)
 )
 
 func updatePrometheusMetrics(v [25]float64) {
@@ -68,4 +92,13 @@ func updatePrometheusMetrics(v [25]float64) {
 	frequencyMetric.WithLabelValues("A").Set(v[13])
 	frequencyMetric.WithLabelValues("B").Set(v[14])
 	frequencyMetric.WithLabelValues("C").Set(v[15])
+	apparentPowerMetric.WithLabelValues("A").Set(v[16])
+	apparentPowerMetric.WithLabelValues("B").Set(v[17])
+	apparentPowerMetric.WithLabelValues("C").Set(v[18])
+	reactivePowerMetric.WithLabelValues("A").Set(v[19])
+	reactivePowerMetric.WithLabelValues("B").Set(v[20])
+	reactivePowerMetric.WithLabelValues("C").Set(v[21])
+	powerFactorMetric.WithLabelValues("A").Set(v[22])
+	powerFactorMetric.WithLabelValues("B").Set(v[23])
+	powerFactorMetric.WithLabelValues("C").Set(v[24])
 }


### PR DESCRIPTION
Add remaining readout values to the Prometheus metrics endpoint.
* Apparent power.
* Reactive power.
* Power factor.

Fix frequency metric name to be more consistent with the other metric names.