### PR TITLE
 Adjust MQTT Client ID

### DIFF
--- a/src/readout/mqtt.go
+++ b/src/readout/mqtt.go
@@ -15,7 +15,7 @@ func newMQTTClient(c *smartpi.Config) (mqttclient MQTT.Client) {
 	log.Debugf("Connecting to MQTT broker at %s", (c.MQTTbroker + ":" + c.MQTTbrokerport))
 	//create a MQTTClientOptions struct setting the broker address, clientid, user and password
 	opts := MQTT.NewClientOptions().AddBroker("tcp://" + c.MQTTbroker + ":" + c.MQTTbrokerport)
-	opts.SetClientID(c.Serial)
+	opts.SetClientID("SmartPi-" + c.Name)
 	opts.SetUsername(c.MQTTuser)
 	opts.SetPassword(c.MQTTpass)
 	opts.SetAutoReconnect(true)

--- a/src/smartpi/ade7878.go
+++ b/src/smartpi/ade7878.go
@@ -393,7 +393,6 @@ func ReadActiveWatts(d *i2c.Device, c *Config, phase string) (watts float64) {
 		pcf = 200.0 / (float64(c.CTTypePrimaryCurrent[phase]))
 	}
 
-
 	outcome := float64(DeviceFetchInt(d, 4, command))
 	if c.MeasureCurrent[phase] {
 		watts = outcome * CTTypes[c.CTType[phase]].PowerCorrectionFactor / pcf
@@ -420,7 +419,7 @@ func ReadActiveEnergy(d *i2c.Device, c *Config, phase string) (energy float64) {
 		panic(fmt.Errorf("Invalid phase %q", phase))
 	}
 
-		var pcf float64
+	var pcf float64
 	if c.CTType[phase] == "YHDC_SCT013" {
 		pcf = 1.0
 	} else {
@@ -530,7 +529,6 @@ func ReadReactivePower(d *i2c.Device, c *Config, phase string) float64 {
 		panic(fmt.Errorf("Invalid phase %q", phase))
 	}
 
-
 	var pcf float64
 	if c.CTType[phase] == "YHDC_SCT013" {
 		pcf = 1.0
@@ -539,10 +537,10 @@ func ReadReactivePower(d *i2c.Device, c *Config, phase string) float64 {
 	}
 
 	if c.MeasureCurrent[phase] {
-		
+
 		outcome := float64(DeviceFetchInt(d, 4, command))
 		if c.CurrentDirection[phase] {
-			return outcome * -1 /pcf
+			return outcome * -1 / pcf
 		} else {
 			return outcome / pcf
 		}

--- a/src/smartpi/config.go
+++ b/src/smartpi/config.go
@@ -109,7 +109,7 @@ func (p *Config) ReadParameterFromFile() {
 
 	// [base]
 	p.Serial = cfg.Section("base").Key("serial").String()
-	p.Name = cfg.Section("base").Key("name").String()
+	p.Name = cfg.Section("base").Key("name").MustString("House")
 	// Handle logging levels
 	p.LogLevel, err = log.ParseLevel(cfg.Section("base").Key("loglevel").MustString("info"))
 	if err != nil {


### PR DESCRIPTION
* Use `Name` instead of `Serial`.
* Prepend ID to avoid empty client ID.
* Set default `Name` to "House".
* Cleanup `go fmt`.

Closes: https://github.com/nDenerserve/SmartPi/issues/66