### PR TITLE
Adjustments to readout timing

### DIFF
--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -64,6 +64,8 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 	data := make([]float32, 22)
 	i := 0
 
+	tick := time.Tick(time.Second)
+
 	for {
 		// Restart the accumulator loop every 60 seconds.
 		if i > 59 {
@@ -124,8 +126,8 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			log.Errorf("Sleep duration negative: %s", sleepFor)
 		} else {
 			log.Debugf("Sleeping for %s", sleepFor)
-			time.Sleep(sleepFor)
 		}
+		<- tick
 		i++
 	}
 }

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -64,6 +64,10 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 	data := make([]float32, 22)
 	i := 0
 
+	// Pin the accumulator loop to full minutes.
+	startAt := time.Now().Truncate(time.Minute).Add(time.Minute)
+	<- time.After(time.Until(startAt))
+
 	tick := time.Tick(time.Second)
 
 	for {

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -65,7 +65,7 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 	i := 0
 
 	// Pin the accumulator loop to full minutes.
-	startAt := time.Now().Truncate(time.Minute).Add(time.Minute)
+	startAt := time.Now().Truncate(time.Minute).Add(61 * time.Second)
 	<- time.After(time.Until(startAt))
 
 	tick := time.Tick(time.Second)

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -64,10 +64,6 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 	data := make([]float32, 22)
 	i := 0
 
-	// Pin the accumulator loop to full minutes.
-	startAt := time.Now().Truncate(time.Minute).Add(61 * time.Second)
-	<- time.After(time.Until(startAt))
-
 	tick := time.Tick(time.Second)
 
 	for {

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -125,11 +125,9 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			}
 		}
 
-		sleepFor := (1000 * time.Millisecond) - time.Since(startTime)
-		if int64(sleepFor) <= 0 {
-			log.Errorf("Sleep duration negative: %s", sleepFor)
-		} else {
-			log.Debugf("Sleeping for %s", sleepFor)
+		delay := time.Since(startTime) - (1000 * time.Millisecond)
+		if int64(delay) > 0 {
+			log.Errorf("Readout delayed: %s", delay)
 		}
 		<- tick
 		i++


### PR DESCRIPTION
This addresses readout timing and database timestamps.

- Use Tick instead of Sleep for timing the loop. 
With Sleep each loop takes slightly longer than a second, accumulating over time and causing a drift in the database timestamps.

- Pin database writing to full minutes.
Waiting an appropriate time (up to a minute) before entering the loop allows for consistent database writings at every full minute independent of startup time (though this disregards the ~160ms it takes to reach the write).