### PR TITLE
Add CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+jobs:
+  build_arm:
+    docker:
+    - image:: circleci/golang:1.10
+    working_directory: /go/src/github.com/nDenerserve/SmartPi
+
+    environment:
+      GOARCH: arm
+      GOARM: 7
+
+    steps:
+    - checkout
+    - run: make
+    - store_artifacts:
+        path: bin
+
+workflows:
+  version: 2
+  build:
+    jobs:
+    - build_arm

--- a/makefile
+++ b/makefile
@@ -13,7 +13,9 @@ GOINSTALL=$(GO) install
 GOCLEAN=$(GO) clean
 GOGET=$(GO) get
 
-all: makedir get buildsmartpireadout buildsmartpiserver buildsmartpiftpupload
+pkgs = $(shell $(GO) list ./src/...)
+
+all: format makedir get buildsmartpireadout buildsmartpiserver buildsmartpiftpupload
 #all: makedir get buildsmartpireadout
 
 makedir:
@@ -22,6 +24,10 @@ makedir:
 	@if [ ! -d $(BUILDPATH)/pkg ] ; then mkdir -p $(BUILDPATH)/pkg ; fi
 
 get:
+
+format:
+	@echo "formatting code..."
+	@$(GO) fmt $(pkgs)
 
 buildsmartpireadout:
 	@echo "start building smartpireadout..."


### PR DESCRIPTION
This will automatically build the package as part of the PR process.  This will make it easier to verify that PRs are valid code.

I've also added a `format` function to the makefile to avoid unclean Go code.

In order to activeate this, a repo maintainer will have to connect the project to https://circleci.com.  The project can get one build at a time for free.