### PR TITLE
adaptable logging/measurementfrequency

### DIFF
--- a/config/etc/smartpi
+++ b/config/etc/smartpi
@@ -21,7 +21,7 @@ influxpassword="smart4pi"
 influxdatabase="http://localhost:8086"
 
 [device]
-samplerate=1
+samplerate=60
 i2c_device="/dev/i2c-1"
 power_frequency=50
 ct_type_1=YHDC_SCT013

--- a/config/etc/smartpi
+++ b/config/etc/smartpi
@@ -21,7 +21,8 @@ influxpassword="smart4pi"
 influxdatabase="http://localhost:8086"
 
 [device]
-samplerate=60
+samplerate=1
+loggingrate=60
 i2c_device="/dev/i2c-1"
 power_frequency=50
 ct_type_1=YHDC_SCT013

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nDenerserve/SmartPi
+module github.com/FransTheekrans/SmartPi
 
 require (
 	github.com/auth0/go-jwt-middleware v0.0.0-20200810150920-a32d7af194d1

--- a/public_html/bower.json
+++ b/public_html/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "public_html",
-  "homepage": "https://github.com/nDenerserve/SmartPi",
+  "homepage": "https://github.com/FransTheekrans/SmartPi",
   "authors": [
     "Jens Ramhorst <j.ramhorst@enerserve.eu>"
   ],

--- a/readme.md
+++ b/readme.md
@@ -91,8 +91,8 @@ and set the GOPATH environment variable to point to that location.
 
 ##### Building source
 
-    go get -v github.com/nDenerserve/SmartPi/src/smartpi
-    cd ${GOPATH-$HOME/go}/src/github.com/nDenerserve/SmartPi
+    go get -v github.com/FransTheekrans/SmartPi/src/smartpi
+    cd ${GOPATH-$HOME/go}/src/github.com/FransTheekrans/SmartPi
     make
 
 NOTE: If you need to build from a fork, you will have to symlink your fork into `${GOPATH-$HOME/go}/src/github.com/nDenerserve/` to make golang dependencies work correctly.

--- a/src/main/ftpupload.go
+++ b/src/main/ftpupload.go
@@ -35,7 +35,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nDenerserve/SmartPi/src/smartpi"
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	"github.com/secsy/goftp"
 	log "github.com/sirupsen/logrus"
 )

--- a/src/main/server.go
+++ b/src/main/server.go
@@ -37,9 +37,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
-	"github.com/nDenerserve/SmartPi/src/smartpi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/src/modbus/modbusserver.go
+++ b/src/modbus/modbusserver.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	"github.com/fsnotify/fsnotify"
 	"github.com/goburrow/serial"
-	"github.com/nDenerserve/SmartPi/src/smartpi"
 	"github.com/nDenerserve/mbserver"
 	log "github.com/sirupsen/logrus"
 )

--- a/src/readout/database.go
+++ b/src/readout/database.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/nDenerserve/SmartPi/src/smartpi"
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/src/readout/files.go
+++ b/src/readout/files.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nDenerserve/SmartPi/src/smartpi"
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -125,11 +125,11 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			accumulator.Frequency[p] += readouts.Frequency[p] / (float64(config.Loggingrate))
 
 			if readouts.ActiveWatts[p] >= 0 {
-				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / (60.0 * float64(config.Loggingrate))
+				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) *3600
 			} else {
-				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / (60.0 * float64(config.Loggingrate))
+				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) *3600
 			}
-			wattHourBalanced += readouts.ActiveWatts[p] / (60.0 * float64(config.Loggingrate))
+			wattHourBalanced += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) *3600
 		}
 
 		// Update metrics endpoint.

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -126,12 +126,12 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			accumulator.Frequency[p] += readouts.Frequency[p] / (float64(config.Loggingrate))
 
 			if readouts.ActiveWatts[p] >= 0 {
-				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
+				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / 3600
 			} else {
-				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
+				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / 3600
 			}
-			accumulator.WattHoursBalanced[p] += readouts.ActiveWatts[p] / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
-			wattHourBalanced += readouts.ActiveWatts[p] / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
+			accumulator.WattHoursBalanced[p] += readouts.ActiveWatts[p] / float64(config.Samplerate) / 3600
+			wattHourBalanced += readouts.ActiveWatts[p] / float64(config.Samplerate) / 3600
 		}
 
 		// Update metrics endpoint.

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -58,6 +58,7 @@ func makeReadoutAccumulator() (r smartpi.ReadoutAccumulator) {
 	r.Frequency = make(smartpi.Readings)
 	r.WattHoursConsumed = make(smartpi.Readings)
 	r.WattHoursProduced = make(smartpi.Readings)
+	r.WattHoursBalanced = make(smartpi.Readings)
 	return r
 }
 
@@ -125,11 +126,12 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			accumulator.Frequency[p] += readouts.Frequency[p] / (float64(config.Loggingrate))
 
 			if readouts.ActiveWatts[p] >= 0 {
-				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) *3600
+				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) * 3600
 			} else {
-				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) *3600
+				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) * 3600
 			}
-			wattHourBalanced += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) *3600
+			accumulator.WattHoursBalanced[p] += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) * 3600
+			wattHourBalanced += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) * 3600
 		}
 
 		// Update metrics endpoint.

--- a/src/readout/main.go
+++ b/src/readout/main.go
@@ -126,12 +126,12 @@ func pollSmartPi(config *smartpi.Config, device *i2c.Device) {
 			accumulator.Frequency[p] += readouts.Frequency[p] / (float64(config.Loggingrate))
 
 			if readouts.ActiveWatts[p] >= 0 {
-				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) * 3600
+				accumulator.WattHoursConsumed[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
 			} else {
-				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / config.Samplerate / float64(config.Loggingrate) * 3600
+				accumulator.WattHoursProduced[p] += math.Abs(readouts.ActiveWatts[p]) / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
 			}
-			accumulator.WattHoursBalanced[p] += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) * 3600
-			wattHourBalanced += readouts.ActiveWatts[p] / config.Samplerate / float64(config.Loggingrate) * 3600
+			accumulator.WattHoursBalanced[p] += readouts.ActiveWatts[p] / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
+			wattHourBalanced += readouts.ActiveWatts[p] / float64(config.Samplerate) / float64(config.Loggingrate) * 3600
 		}
 
 		// Update metrics endpoint.

--- a/src/readout/mqtt.go
+++ b/src/readout/mqtt.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/eclipse/paho.mqtt.golang"
-	"github.com/nDenerserve/SmartPi/src/smartpi"
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/src/readout/prometheus.go
+++ b/src/readout/prometheus.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/nDenerserve/SmartPi/src/smartpi"
+	"github.com/FransTheekrans/SmartPi/src/smartpi"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/src/smartpi/apihandlersmartpiconfig.go
+++ b/src/smartpi/apihandlersmartpiconfig.go
@@ -34,16 +34,17 @@ import (
 	// "fmt"
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/structs"
-	"github.com/gorilla/context"
-	"github.com/gorilla/mux"
-	"github.com/nDenerserve/SmartPi/src/smartpi/network"
-	"github.com/oleiade/reflections"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"reflect"
 	"strconv"
+
+	"github.com/FransTheekrans/SmartPi/src/smartpi/network"
+	"github.com/fatih/structs"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+	"github.com/oleiade/reflections"
 )
 
 type JSONMessage struct {

--- a/src/smartpi/apihandlersmomentary.go
+++ b/src/smartpi/apihandlersmomentary.go
@@ -41,8 +41,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/FransTheekrans/SmartPi/src/smartpi/network"
 	"github.com/gorilla/mux"
-	"github.com/nDenerserve/SmartPi/src/smartpi/network"
 )
 
 func Index(w http.ResponseWriter, r *http.Request) {

--- a/src/smartpi/config.go
+++ b/src/smartpi/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	I2CDevice            string
 	PowerFrequency       float64
 	Samplerate           int
+	Loggingrate          int
 	Integrator           bool
 	CTType               map[Phase]string
 	CTTypePrimaryCurrent map[Phase]int
@@ -167,7 +168,8 @@ func (p *Config) ReadParameterFromFile() {
 	// [device]
 	p.I2CDevice = cfg.Section("device").Key("i2c_device").MustString("/dev/i2c-1")
 	p.PowerFrequency = cfg.Section("device").Key("power_frequency").MustFloat64(50)
-	p.Samplerate = cfg.Section("device").Key("samplerate").MustInt(60)
+	p.Samplerate = cfg.Section("device").Key("samplerate").MustInt(1)
+	p.Loggingrate = cfg.Section("device").Key("loggingrate").MustInt(60)
 	p.Integrator = cfg.Section("device").Key("integrator").MustBool(false)
 	p.CTType = make(map[Phase]string)
 	p.CTType[PhaseA] = cfg.Section("device").Key("ct_type_1").MustString("YHDC_SCT013")

--- a/src/smartpi/config.go
+++ b/src/smartpi/config.go
@@ -167,7 +167,7 @@ func (p *Config) ReadParameterFromFile() {
 	// [device]
 	p.I2CDevice = cfg.Section("device").Key("i2c_device").MustString("/dev/i2c-1")
 	p.PowerFrequency = cfg.Section("device").Key("power_frequency").MustFloat64(50)
-	p.Samplerate = cfg.Section("device").Key("samplerate").MustInt(1)
+	p.Samplerate = cfg.Section("device").Key("samplerate").MustInt(60)
 	p.Integrator = cfg.Section("device").Key("integrator").MustBool(false)
 	p.CTType = make(map[Phase]string)
 	p.CTType[PhaseA] = cfg.Section("device").Key("ct_type_1").MustString("YHDC_SCT013")

--- a/src/smartpi/influxdatabase.go
+++ b/src/smartpi/influxdatabase.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FransTheekrans/SmartPi/src/smartpi/network"
 	client "github.com/influxdata/influxdb1-client/v2"
-	"github.com/nDenerserve/SmartPi/src/smartpi/network"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/src/smartpi/influxdatabase.go
+++ b/src/smartpi/influxdatabase.go
@@ -66,6 +66,9 @@ func InsertInfluxData(c *Config, t time.Time, v ReadoutAccumulator, consumedWatt
 		"Ep1":     float64(v.WattHoursProduced[PhaseA]),
 		"Ep2":     float64(v.WattHoursProduced[PhaseB]),
 		"Ep3":     float64(v.WattHoursProduced[PhaseC]),
+		"Eb1":     float64(v.WattHoursBalanced[PhaseA]),
+		"Eb2":     float64(v.WattHoursBalanced[PhaseB]),
+		"Eb3":     float64(v.WattHoursBalanced[PhaseC]),
 		"bEc":     float64(consumedWattHourBalanced),
 		"bEp":     float64(producedWattHourBalanced),
 	}

--- a/src/smartpi/tools.go
+++ b/src/smartpi/tools.go
@@ -38,6 +38,7 @@ type ReadoutAccumulator struct {
 	Frequency         Readings
 	WattHoursConsumed Readings
 	WattHoursProduced Readings
+	WattHoursBalanced Readings
 }
 
 func Checkpanic(e error) {

--- a/src/smartpi/usermanagement.go
+++ b/src/smartpi/usermanagement.go
@@ -27,7 +27,7 @@
 package smartpi
 
 import (
-	"github.com/nDenerserve/SmartPi/src/linuxtools"
+	"github.com/FransTheekrans/SmartPi/src/linuxtools"
 )
 
 // "path/filepath"


### PR DESCRIPTION
Hey!

I have your smartpi logger here at home (great thing btw), and have been trying to set it up so it would measure and log at a much higher frequency . Couldn't find anything in the config files, so I started digging into the code and adapted it to suit my needs.
Main changes are in the readout/main.go. I differentiated between loggingrate and samplerate. with samplerate one can define the number of measurements per second, with loggingrate one can define the number of samples that are averaged before the average is written to the database. for example, if you want to measure every second, and log every minute, the samplerate should be 1, and the loggingrate 60.
main changes are in the for loop of the function "pollSmartPi", as you will see.

to do this I had to define an additional parameter in the config file, so this was adapted, together with the config.go-file of the smartpi module to ensure this parameter is parsed.

I'm an engineer, with limited experience in programming, and no experience in golang, so I probably didn't do everything by the book, please excuse me for this. For example, I replaced all references to your github zith references to my fork. this offcourse shouldn't be copied in your main branch. There is probably a better zay, but I don't know that way yet.
thanks and best regards!

Joris