### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add a dependabot config to automatically update Go modules on a monthly
schedule.

Signed-off-by: SuperQ <superq@gmail.com>