### PR TITLE
Issue/influxdb 1.8

### DIFF
--- a/etc/smartpi
+++ b/etc/smartpi
@@ -17,6 +17,7 @@ database_enabled    =true
 sqlite_enabled      =true
 sqlite_dir          ="/var/smartpi/db"
 dir                 ="/var/smartpi/db"
+influxversion       =2
 influxuser          ="smartpi"
 influxpassword      ="smart4pi"
 influxdatabase      ="http://localhost:8086"

--- a/src/repository/config/smartpiconfig_file.go
+++ b/src/repository/config/smartpiconfig_file.go
@@ -57,6 +57,7 @@ type Config struct {
 	DatabaseEnabled bool
 	SQLLiteEnabled  bool
 	DatabaseDir     string
+	Influxversion   string
 	Influxuser      string
 	Influxpassword  string
 	Influxdatabase  string
@@ -169,6 +170,7 @@ func (p *Config) ReadParameterFromFile() {
 	p.DatabaseEnabled = cfg.Section("database").Key("database_enabled").MustBool(true)
 	p.SQLLiteEnabled = cfg.Section("database").Key("sqlite_enabled").MustBool(true)
 	p.DatabaseDir = cfg.Section("database").Key("sqlite_dir").MustString("/var/smartpi/db")
+	p.Influxversion = cfg.Section("database").Key("influxversion").MustString("2")
 	p.Influxuser = cfg.Section("database").Key("influxuser").MustString("smartpi")
 	p.Influxpassword = cfg.Section("database").Key("influxpassword").MustString("smart4pi")
 	p.Influxdatabase = cfg.Section("database").Key("influxdatabase").MustString("http://localhost:8086")

--- a/src/smartpi/influxdatabase.go
+++ b/src/smartpi/influxdatabase.go
@@ -90,7 +90,8 @@ func InsertInfluxDataV1(c *config.Config, t time.Time, v ReadoutAccumulator, con
 func InsertInfluxData(c *config.Config, t time.Time, v ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
 
 	if c.Influxversion == "1" {
-		return InsertInfluxDataV1(c, t, v, consumedWattHourBalanced, producedWattHourBalanced)
+		InsertInfluxDataV1(c, t, v, consumedWattHourBalanced, producedWattHourBalanced)
+		return
 	}
 
 	client := influxdb2.NewClient(c.Influxdatabase, c.InfluxAPIToken)
@@ -184,7 +185,8 @@ func InsertFastDataV1(c *config.Config, t time.Time, values *ADE7878Readout) {
 func InsertFastData(c *config.Config, t time.Time, values *ADE7878Readout) {
 
 	if c.Influxversion == "1" {
-		return InsertFastDataV1(c, t, values)
+		InsertFastDataV1(c, t, values)
+		return
 	}
 
 	client := influxdb2.NewClient(c.Influxdatabase, c.InfluxAPIToken)

--- a/src/smartpi/influxdatabase.go
+++ b/src/smartpi/influxdatabase.go
@@ -27,7 +27,71 @@ import (
 // 	Current_1, Current_2, Current_3, Current_4, Voltage_1, Voltage_2, Voltage_3, Power_1, Power_2, Power_3, Cosphi_1, Cosphi_2, Cosphi_3, Frequency_1, Frequency_2, Frequency_3, Energy_pos_1, Energy_pos_2, Energy_pos_3, Energy_neg_1, Energy_neg_2, Energy_neg_3 float64
 // }
 
+func InsertInfluxDataV1(c *config.Config, t time.Time, v ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
+
+	dbc, err := client.NewHTTPClient(client.HTTPConfig{
+		Addr:     c.Influxdatabase,
+		Username: c.Influxuser,
+		Password: c.Influxpassword,
+	})
+	if err != nil {
+		log.Printf("Error creating InfluxDB Client: ", err.Error())
+	}
+	defer dbc.Close()
+
+	// Create a new point batch
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  "MeteringData",
+		Precision: "s",
+	})
+
+	// Create a point and add to batch
+	macaddress := network.GetMacAddr()
+	tags := map[string]string{"serial": macaddress, "type": "electric"}
+	fields := map[string]interface{}{
+		"I1":      float64(v.Current[models.PhaseA]),
+		"I2":      float64(v.Current[models.PhaseB]),
+		"I3":      float64(v.Current[models.PhaseC]),
+		"I4":      float64(v.Current[models.PhaseN]),
+		"U1":      float64(v.Voltage[models.PhaseA]),
+		"U2":      float64(v.Voltage[models.PhaseB]),
+		"U3":      float64(v.Voltage[models.PhaseC]),
+		"P1":      float64(v.ActiveWatts[models.PhaseA]),
+		"P2":      float64(v.ActiveWatts[models.PhaseB]),
+		"P3":      float64(v.ActiveWatts[models.PhaseC]),
+		"CosPhi1": float64(v.CosPhi[models.PhaseA]),
+		"CosPhi2": float64(v.CosPhi[models.PhaseB]),
+		"CosPhi3": float64(v.CosPhi[models.PhaseC]),
+		"F1":      float64(v.Frequency[models.PhaseA]),
+		"F2":      float64(v.Frequency[models.PhaseB]),
+		"F3":      float64(v.Frequency[models.PhaseC]),
+		"Ec1":     float64(v.WattHoursConsumed[models.PhaseA]),
+		"Ec2":     float64(v.WattHoursConsumed[models.PhaseB]),
+		"Ec3":     float64(v.WattHoursConsumed[models.PhaseC]),
+		"Ep1":     float64(v.WattHoursProduced[models.PhaseA]),
+		"Ep2":     float64(v.WattHoursProduced[models.PhaseB]),
+		"Ep3":     float64(v.WattHoursProduced[models.PhaseC]),
+		"bEc":     float64(consumedWattHourBalanced),
+		"bEp":     float64(producedWattHourBalanced),
+	}
+	pt, err := client.NewPoint("data", tags, fields, time.Now())
+	if err != nil {
+		log.Printf("Error: ", err.Error())
+	}
+	bp.AddPoint(pt)
+
+	// Write the batch
+	err = dbc.Write(bp)
+	if err != nil {
+		log.Printf("Error: ", err.Error())
+	}
+}
+
 func InsertInfluxData(c *config.Config, t time.Time, v ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
+
+	if c.Influxversion == "1" {
+		return InsertInfluxDataV1(c, t, v, consumedWattHourBalanced, producedWattHourBalanced)
+	}
 
 	client := influxdb2.NewClient(c.Influxdatabase, c.InfluxAPIToken)
 	defer client.Close()
@@ -70,7 +134,58 @@ func InsertInfluxData(c *config.Config, t time.Time, v ReadoutAccumulator, consu
 	writeAPI.WritePoint(context.Background(), pt)
 }
 
+func InsertFastDataV1(c *config.Config, t time.Time, values *ADE7878Readout) {
+
+	dbc, err := client.NewHTTPClient(client.HTTPConfig{
+		Addr:     c.Influxdatabase,
+		Username: c.Influxuser,
+		Password: c.Influxpassword,
+	})
+	if err != nil {
+		log.Printf("Error creating InfluxDB Client: ", err.Error())
+	}
+	defer dbc.Close()
+
+	// Create a new point batch
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  "FastMeasurement",
+		Precision: "s",
+	})
+
+	// Create a point and add to batch
+	macaddress := network.GetMacAddr()
+	tags := map[string]string{"serial": macaddress, "type": "electric"}
+	fields := map[string]interface{}{
+		"I1": float64(values.Current[models.PhaseA]),
+		"I2": float64(values.Current[models.PhaseB]),
+		"I3": float64(values.Current[models.PhaseC]),
+		"I4": float64(values.Current[models.PhaseN]),
+		"U1": float64(values.Voltage[models.PhaseA]),
+		"U2": float64(values.Voltage[models.PhaseB]),
+		"U3": float64(values.Voltage[models.PhaseC]),
+		"P1": float64(values.ActiveWatts[models.PhaseA]),
+		"P2": float64(values.ActiveWatts[models.PhaseB]),
+		"P3": float64(values.ActiveWatts[models.PhaseC]),
+	}
+	pt, err := client.NewPoint("data", tags, fields, time.Now())
+	log.Info(fields)
+	if err != nil {
+		log.Printf("Error: ", err.Error())
+	}
+	bp.AddPoint(pt)
+
+	// Write the batch
+	err = dbc.Write(bp)
+	if err != nil {
+		log.Printf("Error: ", err.Error())
+	}
+}
+
 func InsertFastData(c *config.Config, t time.Time, values *ADE7878Readout) {
+
+	if c.Influxversion == "1" {
+		return InsertFastDataV1(c, t, values)
+	}
 
 	client := influxdb2.NewClient(c.Influxdatabase, c.InfluxAPIToken)
 	defer client.Close()


### PR DESCRIPTION
Hi Jens, this issue implements a fallback for InfluxDB 1.x for older SmartPi version (non 64 bit systems) since InfluxDB 2.x requires 64bit architecture. There is some code duplication in the fallback-functions, so I suggest to do a bit refactoring in the future.