### PR TITLE
Fix infinite loop

### DIFF
--- a/src/dcreadout/readout.go
+++ b/src/dcreadout/readout.go
@@ -245,9 +245,5 @@ func main() {
 		os.Exit(0)
 	}
 
-	go pollSmartPiDC(smartpidcconfig)
-
-	for {
-	}
-
+	pollSmartPiDC(smartpidcconfig)
 }


### PR DESCRIPTION
Remove unecessary goroutine. Empty `for {}` loops consume 100% of a CPU core.