### PR TITLE
Add configurable MQTT publish interval with readout aggregation

### DIFF
--- a/etc/smartpi
+++ b/etc/smartpi
@@ -40,25 +40,27 @@ decimalpoint =
 timeformat   = 
 
 [mqtt]
-mqtt_enabled       = false
-mqtt_broker_scheme = tcp://
-mqtt_broker_url    = 
-mqtt_broker_port   = 
-mqtt_username      = 
-mqtt_password      = 
-mqtt_topic         = 
-mqtt_qos           = 0
+mqtt_enabled          = false
+mqtt_broker_scheme    = tcp://
+mqtt_broker_url       = 
+mqtt_broker_port      = 
+mqtt_username         = 
+mqtt_password         = 
+mqtt_topic            = 
+mqtt_qos              = 0
+mqtt_publish_interval = 0
 
 [smartpicloud]
-smartpicloud_enabled            = false
-smartpicloud_username           = 
-smartpicloud_mqtt_broker_scheme = tcp://
-smartpicloud_mqtt_broker_url    = 
-smartpicloud_mqtt_broker_port   = 
-smartpicloud_mqtt_username      = 
-smartpicloud_mqtt_password      = 
-smartpicloud_mqtt_topic         = 
-smartpicloud_mqtt_qos           = 0
+smartpicloud_enabled               = false
+smartpicloud_username              = 
+smartpicloud_mqtt_broker_scheme    = tcp://
+smartpicloud_mqtt_broker_url       = 
+smartpicloud_mqtt_broker_port      = 
+smartpicloud_mqtt_username         = 
+smartpicloud_mqtt_password         = 
+smartpicloud_mqtt_topic            = 
+smartpicloud_mqtt_qos              = 0
+smartpicloud_mqtt_publish_interval = 0
 
 [modbus]
 modbus_rtu_enabled   = false

--- a/src/models/acreadout.go
+++ b/src/models/acreadout.go
@@ -1,13 +1,6 @@
 package models
 
+// Readings holds one measured quantity for all phases. A phase that was not
+// measured simply has no entry, which reads back as zero but can still be told
+// apart from a measured zero by looking up the key.
 type Readings map[SmartPiPhase]float64
-
-type ReadoutAccumulator struct {
-	Current           Readings
-	Voltage           Readings
-	ActiveWatts       Readings
-	CosPhi            Readings
-	Frequency         Readings
-	WattHoursConsumed Readings
-	WattHoursProduced Readings
-}

--- a/src/models/readoutaggregator.go
+++ b/src/models/readoutaggregator.go
@@ -1,0 +1,159 @@
+package models
+
+import "math"
+
+// ReadoutAggregator condenses all samples of one publication window into a
+// single ADE7878Readout. Instantaneous quantities (current, voltage, power,
+// frequency) are averaged over the samples actually collected, energy
+// quantities are summed up so that no energy gets lost when readouts are
+// published less often than they are measured.
+//
+// The sample count is tracked instead of being derived from the configured
+// samplerate, so the aggregation stays correct if samples are dropped or the
+// samplerate is changed at runtime.
+type ReadoutAggregator struct {
+	// samples counts the readouts collected in the current window. Everything
+	// below holds running sums over exactly those samples.
+	samples int
+
+	current       Readings
+	voltage       Readings
+	activeWatts   Readings
+	cosPhi        Readings
+	frequency     Readings
+	apparentPower Readings
+	reactivePower Readings
+	powerFactor   Readings
+
+	activeEnergy      Readings
+	energyconsumption Readings
+	energyproduction  Readings
+
+	// wattHourBalanced is the signed energy balance over all phases, summed up
+	// over the window. A negative value means the window produced more than it
+	// consumed.
+	wattHourBalanced float64
+}
+
+// NewReadoutAggregator returns an aggregator with an empty window.
+func NewReadoutAggregator() *ReadoutAggregator {
+	a := new(ReadoutAggregator)
+	a.Reset()
+	return a
+}
+
+// Reset starts a new publication window.
+func (a *ReadoutAggregator) Reset() {
+	a.samples = 0
+	a.current = make(Readings)
+	a.voltage = make(Readings)
+	a.activeWatts = make(Readings)
+	a.cosPhi = make(Readings)
+	a.frequency = make(Readings)
+	a.apparentPower = make(Readings)
+	a.reactivePower = make(Readings)
+	a.powerFactor = make(Readings)
+	a.activeEnergy = make(Readings)
+	a.energyconsumption = make(Readings)
+	a.energyproduction = make(Readings)
+	a.wattHourBalanced = 0.0
+}
+
+// Samples returns the number of readouts collected since the last reset.
+func (a *ReadoutAggregator) Samples() int {
+	return a.samples
+}
+
+// Add feeds one sample together with its balanced energy into the aggregator.
+// Only the phases actually present in the readout are touched, so a phase that
+// is not measured never contributes to the average of another one.
+func (a *ReadoutAggregator) Add(v *ADE7878Readout, wattHourBalanced float64) {
+	a.samples++
+	addReadings(a.current, v.Current)
+	addReadings(a.voltage, v.Voltage)
+	addReadings(a.activeWatts, v.ActiveWatts)
+	addReadings(a.cosPhi, v.CosPhi)
+	addReadings(a.frequency, v.Frequency)
+	addReadings(a.apparentPower, v.ApparentPower)
+	addReadings(a.reactivePower, v.ReactivePower)
+	addReadings(a.powerFactor, v.PowerFactor)
+	addReadings(a.activeEnergy, v.ActiveEnergy)
+	addReadings(a.energyconsumption, v.Energyconsumption)
+	addReadings(a.energyproduction, v.Energyproduction)
+	a.wattHourBalanced += wattHourBalanced
+}
+
+// Snapshot returns the aggregated readout of the current window together with
+// the summed up balanced energy. It does not reset the aggregator.
+func (a *ReadoutAggregator) Snapshot() (ADE7878Readout, float64) {
+	r := ADE7878Readout{
+		Current:           make(Readings),
+		Voltage:           make(Readings),
+		ActiveWatts:       make(Readings),
+		CosPhi:            make(Readings),
+		Frequency:         make(Readings),
+		ApparentPower:     make(Readings),
+		ReactivePower:     make(Readings),
+		PowerFactor:       make(Readings),
+		ActiveEnergy:      make(Readings),
+		Energyconsumption: make(Readings),
+		Energyproduction:  make(Readings),
+	}
+	// An empty window has no meaningful values and must not divide by zero.
+	if a.samples == 0 {
+		return r, 0.0
+	}
+	samples := float64(a.samples)
+
+	meanReadings(r.Current, a.current, samples)
+	meanReadings(r.Voltage, a.voltage, samples)
+	meanReadings(r.ActiveWatts, a.activeWatts, samples)
+	meanReadings(r.Frequency, a.frequency, samples)
+	meanReadings(r.ApparentPower, a.apparentPower, samples)
+	meanReadings(r.ReactivePower, a.reactivePower, samples)
+	meanReadings(r.PowerFactor, a.powerFactor, samples)
+
+	// Energy is summed up, not averaged.
+	copyReadings(r.ActiveEnergy, a.activeEnergy)
+	copyReadings(r.Energyconsumption, a.energyconsumption)
+	copyReadings(r.Energyproduction, a.energyproduction)
+
+	// cos phi is a displacement factor and must not be averaged arithmetically:
+	// when the power direction changes within the window the individual values
+	// cancel each other out. Averaging the power phasor instead keeps both the
+	// magnitude and the sign of the aggregated value meaningful. Without any
+	// power in the window the phasor is undefined, so the plain mean is kept.
+	for p := range a.cosPhi {
+		activeWatts := a.activeWatts[p] / samples
+		reactivePower := a.reactivePower[p] / samples
+		if apparent := math.Hypot(activeWatts, reactivePower); apparent > 0 {
+			r.CosPhi[p] = activeWatts / apparent
+		} else {
+			r.CosPhi[p] = a.cosPhi[p] / samples
+		}
+	}
+
+	return r, a.wattHourBalanced
+}
+
+// addReadings adds every reading of src to the matching entry in dst.
+func addReadings(dst Readings, src Readings) {
+	for p, value := range src {
+		dst[p] += value
+	}
+}
+
+// meanReadings writes the mean of every summed reading in src to dst.
+func meanReadings(dst Readings, src Readings, samples float64) {
+	for p, value := range src {
+		dst[p] = value / samples
+	}
+}
+
+// copyReadings transfers every reading of src to dst unchanged. It is used for
+// the quantities that are summed up rather than averaged.
+func copyReadings(dst Readings, src Readings) {
+	for p, value := range src {
+		dst[p] = value
+	}
+}

--- a/src/smartpi/config/smartpiconfig_file.go
+++ b/src/smartpi/config/smartpiconfig_file.go
@@ -93,6 +93,10 @@ type SmartPiConfig struct {
 	MQTTpass         string
 	MQTTtopic        string
 	MQTTQoS          uint8
+	// MQTTinterval is the readout publication interval in seconds. Zero (the
+	// default) publishes every sample, any larger value publishes one
+	// aggregated readout per interval.
+	MQTTinterval int
 
 	// [smartpicloud]
 	SmartpicloudEnabled          bool
@@ -104,6 +108,10 @@ type SmartPiConfig struct {
 	SmartpicloudMQTTpass         string
 	SmartpicloudMQTTtopic        string
 	SmartpicloudMQTTQoS          uint8
+	// SmartpicloudMQTTinterval is the readout publication interval in seconds
+	// for the cloud connection, independent of MQTTinterval. Zero publishes
+	// every sample.
+	SmartpicloudMQTTinterval int
 
 	// [modbus slave]
 	ModbusRTUenabled bool
@@ -220,6 +228,7 @@ func (p *SmartPiConfig) ReadParameterFromFile() {
 	p.MQTTpass = cfg.Section("mqtt").Key("mqtt_password").String()
 	p.MQTTtopic = cfg.Section("mqtt").Key("mqtt_topic").String()
 	p.MQTTQoS = uint8(cfg.Section("mqtt").Key("mqtt_qos").MustUint(0))
+	p.MQTTinterval = cfg.Section("mqtt").Key("mqtt_publish_interval").MustInt(0)
 
 	// [smartpicloud]
 	p.SmartpicloudEnabled = cfg.Section("smartpicloud").Key("smartpicloud_enabled").MustBool(false)
@@ -230,6 +239,7 @@ func (p *SmartPiConfig) ReadParameterFromFile() {
 	p.SmartpicloudMQTTpass = cfg.Section("smartpicloud").Key("smartpicloud_mqtt_password").String()
 	p.SmartpicloudMQTTtopic = "smartpiac/" + cfg.Section("smartpicloud").Key("smartpicloud_mqtt_username").String()
 	p.SmartpicloudMQTTQoS = uint8(cfg.Section("smartpicloud").Key("smartpicloud_mqtt_qos").MustUint(0))
+	p.SmartpicloudMQTTinterval = cfg.Section("smartpicloud").Key("smartpicloud_mqtt_publish_interval").MustInt(0)
 
 	// [modbus slave]
 	p.ModbusRTUenabled = cfg.Section("modbus").Key("modbus_rtu_enabled").MustBool(false)
@@ -297,6 +307,7 @@ func (p *SmartPiConfig) SaveParameterToFile() {
 	_, err = cfg.Section("mqtt").NewKey("mqtt_password", p.MQTTpass)
 	_, err = cfg.Section("mqtt").NewKey("mqtt_topic", p.MQTTtopic)
 	_, err = cfg.Section("mqtt").NewKey("mqtt_qos", strconv.FormatUint(uint64(p.MQTTQoS), 10))
+	_, err = cfg.Section("mqtt").NewKey("mqtt_publish_interval", strconv.FormatInt(int64(p.MQTTinterval), 10))
 
 	// [smartpicloud]
 	_, err = cfg.Section("smartpicloud").NewKey("smartpicloud_enabled", strconv.FormatBool(p.SmartpicloudEnabled))
@@ -306,6 +317,7 @@ func (p *SmartPiConfig) SaveParameterToFile() {
 	_, err = cfg.Section("smartpicloud").NewKey("smartpicloud_mqtt_username", p.SmartpicloudMQTTuser)
 	_, err = cfg.Section("smartpicloud").NewKey("smartpicloud_mqtt_password", p.SmartpicloudMQTTpass)
 	_, err = cfg.Section("smartpicloud").NewKey("smartpicloud_mqtt_qos", strconv.FormatUint(uint64(p.SmartpicloudMQTTQoS), 10))
+	_, err = cfg.Section("smartpicloud").NewKey("smartpicloud_mqtt_publish_interval", strconv.FormatInt(int64(p.SmartpicloudMQTTinterval), 10))
 
 	// [modbus slave]
 	_, err = cfg.Section("modbus").NewKey("modbus_rtu_enabled", strconv.FormatBool(p.ModbusRTUenabled))

--- a/src/smartpiac/connectivity/mqtt.go
+++ b/src/smartpiac/connectivity/mqtt.go
@@ -14,6 +14,9 @@ import (
 	smartpiacDevice "github.com/nDenerserve/SmartPi/smartpiac/device"
 )
 
+// NewMQTTClient connects to the local MQTT broker. A failed connection is only
+// logged, because the client reconnects on its own and the publish functions
+// retry before every publication.
 func NewMQTTClient(c *config.SmartPiConfig) (mqttclient mqtt.Client) {
 	log.Debugf("Connecting to MQTT broker at %s", (c.MQTTbroker + ":" + c.MQTTbrokerport))
 	//create a MQTTClientOptions struct setting the broker address, clientid, user and password
@@ -35,6 +38,10 @@ func NewMQTTClient(c *config.SmartPiConfig) (mqttclient mqtt.Client) {
 	return mqttclient
 }
 
+// publishMQTT publishes a single value to one topic. status is shared across a
+// publication sequence: once a publication has failed it stays false and the
+// remaining values of that sequence are skipped, so that a broken connection
+// does not block the measurement loop for every single topic.
 func publishMQTT(m mqtt.Client, qos uint8, status *bool, t string, v float64) bool {
 	if *status {
 		log.Debug("  -> ", t, ":", v)
@@ -51,6 +58,10 @@ func publishMQTT(m mqtt.Client, qos uint8, status *bool, t string, v float64) bo
 	return false
 }
 
+// PublishMQTTReadouts publishes one set of readouts to the local broker. The
+// values are either a single sample or, if a publication interval is configured,
+// the aggregated values of the last interval - the topics are the same in both
+// cases.
 func PublishMQTTReadouts(c *config.SmartPiConfig, mqttclient mqtt.Client, values *models.ADE7878Readout, wattHourBalanced float64) {
 	var pTotalBalanced float64
 	//[basetopic]/[node]/[keyname]
@@ -86,6 +97,10 @@ func PublishMQTTReadouts(c *config.SmartPiConfig, mqttclient mqtt.Client, values
 	}
 }
 
+// PublishMQTTCalculations publishes the calculated minute values to the local
+// broker: the consumed and produced energy of the last minute (ec1m, ep1m) and
+// the totals from the persistent counter files (cc, pc). This always runs once
+// per minute, independent of the readout publication interval.
 func PublishMQTTCalculations(c *config.SmartPiConfig, mqttclient mqtt.Client, ec1m float64, ep1m float64, cc float64, pc float64) {
 
 	//[basetopic]/[node]/[keyname]
@@ -109,6 +124,8 @@ func PublishMQTTCalculations(c *config.SmartPiConfig, mqttclient mqtt.Client, ec
 	}
 }
 
+// NewSmartPicloudMQTTClient connects to the SmartPicloud broker. It behaves
+// exactly like NewMQTTClient but uses the cloud credentials.
 func NewSmartPicloudMQTTClient(c *config.SmartPiConfig) (mqttclient mqtt.Client) {
 	log.Debugf("Connecting to SmartPiMQTT broker at %s", (c.SmartpicloudMQTTbroker + ":" + c.SmartpicloudMQTTbrokerport))
 	//create a MQTTClientOptions struct setting the broker address, clientid, user and password
@@ -130,6 +147,9 @@ func NewSmartPicloudMQTTClient(c *config.SmartPiConfig) (mqttclient mqtt.Client)
 	return mqttclient
 }
 
+// PublishSmartPicloudMQTTReadouts publishes one set of readouts to SmartPicloud.
+// It mirrors PublishMQTTReadouts but uses the cloud topic and QoS, and is
+// throttled by its own publication interval.
 func PublishSmartPicloudMQTTReadouts(c *config.SmartPiConfig, mqttclient mqtt.Client, values *models.ADE7878Readout, wattHourBalanced float64) {
 	var pTotalBalanced float64
 	//[basetopic]/[node]/[keyname]
@@ -165,6 +185,8 @@ func PublishSmartPicloudMQTTReadouts(c *config.SmartPiConfig, mqttclient mqtt.Cl
 	}
 }
 
+// PublishSmartPicloudMQTTCalculations publishes the calculated minute values to
+// SmartPicloud, see PublishMQTTCalculations.
 func PublishSmartPicloudMQTTCalculations(c *config.SmartPiConfig, mqttclient mqtt.Client, ec1m float64, ep1m float64, cc float64, pc float64) {
 
 	//[basetopic]/[node]/[keyname]

--- a/src/smartpiac/database/database.go
+++ b/src/smartpiac/database/database.go
@@ -15,7 +15,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func UpdateInfluxDatabase(c *config.SmartPiConfig, data models.ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
+// UpdateInfluxDatabase stores the aggregated values of one minute. It is called
+// once per minute when individual samples are not stored.
+func UpdateInfluxDatabase(c *config.SmartPiConfig, data *models.ADE7878Readout, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
 	t := time.Now()
 
 	logLine := "## InfluxDB database update minute values ##"

--- a/src/smartpiac/database/influx.go
+++ b/src/smartpiac/database/influx.go
@@ -29,7 +29,11 @@ import (
 // 	Current_1, Current_2, Current_3, Current_4, Voltage_1, Voltage_2, Voltage_3, Power_1, Power_2, Power_3, Cosphi_1, Cosphi_2, Cosphi_3, Frequency_1, Frequency_2, Frequency_3, Energy_pos_1, Energy_pos_2, Energy_pos_3, Energy_neg_1, Energy_neg_2, Energy_neg_3 float64
 // }
 
-func InsertInfluxDataV1(c *config.SmartPiConfig, t time.Time, v models.ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
+// InsertInfluxDataV1 writes one aggregated minute record to an InfluxDB 1.x
+// server. v carries the averaged instantaneous values and the summed energy of
+// the last minute, consumedWattHourBalanced and producedWattHourBalanced are the
+// two unsigned halves of the minute's energy balance.
+func InsertInfluxDataV1(c *config.SmartPiConfig, t time.Time, v *models.ADE7878Readout, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
 
 	dbc, err := client.NewHTTPClient(client.HTTPConfig{
 		Addr:     c.Influxdatabase,
@@ -67,12 +71,12 @@ func InsertInfluxDataV1(c *config.SmartPiConfig, t time.Time, v models.ReadoutAc
 		"F1":      float64(v.Frequency[models.PhaseA]),
 		"F2":      float64(v.Frequency[models.PhaseB]),
 		"F3":      float64(v.Frequency[models.PhaseC]),
-		"Ec1":     float64(v.WattHoursConsumed[models.PhaseA]),
-		"Ec2":     float64(v.WattHoursConsumed[models.PhaseB]),
-		"Ec3":     float64(v.WattHoursConsumed[models.PhaseC]),
-		"Ep1":     float64(v.WattHoursProduced[models.PhaseA]),
-		"Ep2":     float64(v.WattHoursProduced[models.PhaseB]),
-		"Ep3":     float64(v.WattHoursProduced[models.PhaseC]),
+		"Ec1":     float64(v.Energyconsumption[models.PhaseA]),
+		"Ec2":     float64(v.Energyconsumption[models.PhaseB]),
+		"Ec3":     float64(v.Energyconsumption[models.PhaseC]),
+		"Ep1":     float64(v.Energyproduction[models.PhaseA]),
+		"Ep2":     float64(v.Energyproduction[models.PhaseB]),
+		"Ep3":     float64(v.Energyproduction[models.PhaseC]),
 		"bEc":     float64(consumedWattHourBalanced),
 		"bEp":     float64(producedWattHourBalanced),
 	}
@@ -89,7 +93,9 @@ func InsertInfluxDataV1(c *config.SmartPiConfig, t time.Time, v models.ReadoutAc
 	}
 }
 
-func InsertInfluxData(c *config.SmartPiConfig, t time.Time, v models.ReadoutAccumulator, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
+// InsertInfluxData writes one aggregated minute record to InfluxDB, dispatching
+// to the 1.x client if the configuration asks for it.
+func InsertInfluxData(c *config.SmartPiConfig, t time.Time, v *models.ADE7878Readout, consumedWattHourBalanced float64, producedWattHourBalanced float64) {
 
 	if c.Influxversion == "1" {
 		InsertInfluxDataV1(c, t, v, consumedWattHourBalanced, producedWattHourBalanced)
@@ -123,12 +129,12 @@ func InsertInfluxData(c *config.SmartPiConfig, t time.Time, v models.ReadoutAccu
 		"F1":      float64(v.Frequency[models.PhaseA]),
 		"F2":      float64(v.Frequency[models.PhaseB]),
 		"F3":      float64(v.Frequency[models.PhaseC]),
-		"Ec1":     float64(v.WattHoursConsumed[models.PhaseA]),
-		"Ec2":     float64(v.WattHoursConsumed[models.PhaseB]),
-		"Ec3":     float64(v.WattHoursConsumed[models.PhaseC]),
-		"Ep1":     float64(v.WattHoursProduced[models.PhaseA]),
-		"Ep2":     float64(v.WattHoursProduced[models.PhaseB]),
-		"Ep3":     float64(v.WattHoursProduced[models.PhaseC]),
+		"Ec1":     float64(v.Energyconsumption[models.PhaseA]),
+		"Ec2":     float64(v.Energyconsumption[models.PhaseB]),
+		"Ec3":     float64(v.Energyconsumption[models.PhaseC]),
+		"Ep1":     float64(v.Energyproduction[models.PhaseA]),
+		"Ep2":     float64(v.Energyproduction[models.PhaseB]),
+		"Ep3":     float64(v.Energyproduction[models.PhaseC]),
 		"bEc":     float64(consumedWattHourBalanced),
 		"bEp":     float64(producedWattHourBalanced),
 	}

--- a/src/smartpiac/readout.go
+++ b/src/smartpiac/readout.go
@@ -57,17 +57,9 @@ import (
 	"github.com/prometheus/common/version"
 )
 
-func makeReadoutAccumulator() (r models.ReadoutAccumulator) {
-	r.Current = make(models.Readings)
-	r.Voltage = make(models.Readings)
-	r.ActiveWatts = make(models.Readings)
-	r.CosPhi = make(models.Readings)
-	r.Frequency = make(models.Readings)
-	r.WattHoursConsumed = make(models.Readings)
-	r.WattHoursProduced = make(models.Readings)
-	return r
-}
-
+// makeReadout returns an empty readout with all reading maps allocated. A fresh
+// readout is built for every sample so that a phase which is not measured in
+// this round simply has no entry instead of carrying over a stale value.
 func makeReadout() (r models.ADE7878Readout) {
 	r.Current = make(models.Readings)
 	r.Voltage = make(models.Readings)
@@ -83,11 +75,32 @@ func makeReadout() (r models.ADE7878Readout) {
 	return r
 }
 
+// pollSmartPi is the measurement loop of the readout daemon. It never returns
+// and is meant to be run in its own goroutine.
+//
+// The loop is driven by a ticker derived from the configured samplerate. Every
+// tick all phases are read from the ADE7878 and the resulting readout is fed to
+// the various sinks, each of which runs on its own schedule:
+//
+//   - Prometheus metrics and the shared file are updated on every sample.
+//   - MQTT and SmartPicloud publish on every sample, or - if a publication
+//     interval is configured - once per interval from aggregated values.
+//   - InfluxDB either stores every sample (StoreSamples) or one aggregated
+//     record per minute.
+//   - The persistent energy counter files are updated once per minute.
+//
+// Aggregation is done by models.ReadoutAggregator, which averages instantaneous
+// quantities and sums up energy, so that reducing the publication rate does not
+// lose any energy.
 func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig, device *i2c.Device) {
 	var mqttclient mqtt.Client
 	var smartpicloudMQTTclient mqtt.Client
-	var wattHourBalanced, wattHourBalancedAccu, consumedWattHourBalanced60s, producedWattHourBalanced60s float64
+	// wattHourBalanced holds the balanced energy (sum over all phases, signed)
+	// of the current sample. It is reset after every sample, once all per-sample
+	// sinks have consumed it.
+	var wattHourBalanced, consumedWattHourBalanced60s, producedWattHourBalanced60s float64
 	var p models.SmartPiPhase
+	// Energy counters read back from the persistent counter files.
 	var consumedCounter, producedCounter float64
 	var measureFrequency bool = true
 
@@ -102,11 +115,29 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 		smartpicloudMQTTclient = smartpiacConnectivity.NewSmartPicloudMQTTClient(config)
 	}
 
-	accumulator := makeReadoutAccumulator()
+	// i counts the samples within the current minute and wraps around at
+	// 60*samplerate. It drives everything that happens once per minute.
 	i := 0
+
+	// Minute values for the database and the energy counters are aggregated
+	// over the whole 60 second window.
+	influxAggregator := models.NewReadoutAggregator()
+
+	// Readouts are published on every sample unless a publication interval is
+	// configured. In that case the samples of a window are aggregated and only
+	// the condensed readout is published. Both sinks keep their own aggregator
+	// and their own window, so they can be throttled independently - typically
+	// the cloud connection is published less often than the local broker.
+	mqttAggregator := models.NewReadoutAggregator()
+	smartpicloudAggregator := models.NewReadoutAggregator()
+	mqttWindowStart := time.Now()
+	smartpicloudWindowStart := mqttWindowStart
 
 	tick := time.Tick(time.Duration(1000/acConfig.Samplerate) * time.Millisecond)
 
+	// Measuring the frequency costs ~70ms per phase because the ADE7878 needs to
+	// capture several full cycles. At more than 4 samples per second that no
+	// longer fits into a sampling interval, so frequency measurement is dropped.
 	// disable measuring frequency if samplerate higher than 4 samples/second
 	if acConfig.Samplerate > 4 {
 		measureFrequency = false
@@ -114,34 +145,43 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 
 	for {
 		readouts := makeReadout()
-		// Restart the accumulator loop every 60 seconds.
+		// Restart the accumulator loop every 60 seconds. Normally the minute
+		// block below has already emptied the aggregator at this point; the
+		// reset only matters if the samplerate was changed at runtime and the
+		// counter wrapped without the minute block ever firing. In that case
+		// the partial window is discarded.
 		if i > (60*acConfig.Samplerate - 1) {
 			i = 0
-			accumulator = makeReadoutAccumulator()
+			influxAggregator.Reset()
 		}
 
 		startTime := time.Now()
 
 		// Update readouts and the accumlator.
+		// The neutral conductor only carries a current reading, all other
+		// quantities are read per main phase.
 		smartpiacDevice.ReadPhase(device, acConfig, models.PhaseN, measureFrequency, &readouts)
-		accumulator.Current[models.PhaseN] += readouts.Current[models.PhaseN] / (60.0 * float64(acConfig.Samplerate))
 		for _, p = range smartpiacDevice.MainPhases {
 			smartpiacDevice.ReadPhase(device, acConfig, p, measureFrequency, &readouts)
-			accumulator.Current[p] += readouts.Current[p] / (60.0 * float64(acConfig.Samplerate))
-			accumulator.Voltage[p] += readouts.Voltage[p] / (60.0 * float64(acConfig.Samplerate))
-			accumulator.ActiveWatts[p] += readouts.ActiveWatts[p] / (60.0 * float64(acConfig.Samplerate))
-			accumulator.CosPhi[p] += readouts.CosPhi[p] / (60.0 * float64(acConfig.Samplerate))
-			accumulator.Frequency[p] += readouts.Frequency[p] / (60.0 * float64(acConfig.Samplerate))
 
+			// Split the active power of this sample into consumed and produced
+			// energy. Dividing by 3600*samplerate converts the power in watts
+			// into the watt hours accumulated during one sampling interval.
+			// Only the matching direction is written, the other one stays unset
+			// so that summing up the two never mixes both directions.
 			if readouts.ActiveWatts[p] >= 0 {
 				readouts.Energyconsumption[p] = math.Abs(readouts.ActiveWatts[p]) / (3600.0 * float64(acConfig.Samplerate))
-				accumulator.WattHoursConsumed[p] += readouts.Energyconsumption[p]
 			} else {
 				readouts.Energyproduction[p] = math.Abs(readouts.ActiveWatts[p]) / (3600.0 * float64(acConfig.Samplerate))
-				accumulator.WattHoursProduced[p] += readouts.Energyproduction[p]
 			}
+			// The balanced energy keeps its sign, so consumption on one phase
+			// and production on another cancel each other out.
 			wattHourBalanced += readouts.ActiveWatts[p] / (3600.0 * float64(acConfig.Samplerate))
 		}
+		// Feed the completed sample into the minute aggregator. This has to
+		// happen after the phase loop, because only then the readout carries the
+		// derived energy values as well.
+		influxAggregator.Add(&readouts, wattHourBalanced)
 
 		// Update metrics endpoint.
 		smartpiacDatabase.UpdatePrometheusMetrics(&readouts, acConfig)
@@ -154,12 +194,35 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 			}
 
 			// Publish readouts to MQTT.
+			// Without a publication interval every sample is sent as it is.
+			// Otherwise the samples are collected and one condensed readout is
+			// published as soon as the window has elapsed.
 			if config.MQTTenabled {
-				smartpiacConnectivity.PublishMQTTReadouts(config, mqttclient, &readouts, wattHourBalanced)
+				if config.MQTTinterval <= 0 {
+					smartpiacConnectivity.PublishMQTTReadouts(config, mqttclient, &readouts, wattHourBalanced)
+				} else {
+					mqttAggregator.Add(&readouts, wattHourBalanced)
+					if time.Since(mqttWindowStart) >= time.Duration(config.MQTTinterval)*time.Second {
+						aggregatedReadouts, aggregatedWattHourBalanced := mqttAggregator.Snapshot()
+						smartpiacConnectivity.PublishMQTTReadouts(config, mqttclient, &aggregatedReadouts, aggregatedWattHourBalanced)
+						mqttAggregator.Reset()
+						mqttWindowStart = time.Now()
+					}
+				}
 			}
 			// Publish readouts to SmartPicloud via MQTT.
 			if config.SmartpicloudEnabled {
-				smartpiacConnectivity.PublishSmartPicloudMQTTReadouts(config, smartpicloudMQTTclient, &readouts, wattHourBalanced)
+				if config.SmartpicloudMQTTinterval <= 0 {
+					smartpiacConnectivity.PublishSmartPicloudMQTTReadouts(config, smartpicloudMQTTclient, &readouts, wattHourBalanced)
+				} else {
+					smartpicloudAggregator.Add(&readouts, wattHourBalanced)
+					if time.Since(smartpicloudWindowStart) >= time.Duration(config.SmartpicloudMQTTinterval)*time.Second {
+						aggregatedReadouts, aggregatedWattHourBalanced := smartpicloudAggregator.Snapshot()
+						smartpiacConnectivity.PublishSmartPicloudMQTTReadouts(config, smartpicloudMQTTclient, &aggregatedReadouts, aggregatedWattHourBalanced)
+						smartpicloudAggregator.Reset()
+						smartpicloudWindowStart = time.Now()
+					}
+				}
 			}
 
 			// Update InfluxDB (FastMeasurement) database.
@@ -168,7 +231,8 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 			if config.DatabaseEnabled && acConfig.StoreSamples {
 				smartpiacDatabase.UpdateSampleInfluxDatabase(config, &readouts, wattHourBalanced)
 			}
-			wattHourBalancedAccu += wattHourBalanced
+			// All per-sample sinks have seen this sample, start over. The minute
+			// aggregator has its own copy of the value.
 			wattHourBalanced = 0
 		}
 
@@ -176,19 +240,29 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 		// Energymeasurement is only enabled if samplerate < 4
 		if i == (60*acConfig.Samplerate - 1) {
 
+			// Condense the last minute into a single readout and immediately
+			// start the next window. minuteWattHourBalanced is the signed energy
+			// balance of the whole minute.
+			minuteReadouts, minuteWattHourBalanced := influxAggregator.Snapshot()
+			influxAggregator.Reset()
+
 			// balanced value
+			// Split the signed balance into the two unsigned directions that the
+			// database and the counter files expect.
 			consumedWattHourBalanced60s = 0.0
 			producedWattHourBalanced60s = 0.0
 
-			if wattHourBalancedAccu >= 0 {
-				consumedWattHourBalanced60s = math.Abs(wattHourBalancedAccu)
+			if minuteWattHourBalanced >= 0 {
+				consumedWattHourBalanced60s = math.Abs(minuteWattHourBalanced)
 			} else {
-				producedWattHourBalanced60s = math.Abs(wattHourBalancedAccu)
+				producedWattHourBalanced60s = math.Abs(minuteWattHourBalanced)
 			}
 
 			// Update InfluxDB database.
+			// When every sample is stored anyway, only the calculated minute
+			// energies are added on top of the samples already written above.
 			if config.DatabaseEnabled && !acConfig.StoreSamples {
-				smartpiacDatabase.UpdateInfluxDatabase(config, accumulator, consumedWattHourBalanced60s, producedWattHourBalanced60s)
+				smartpiacDatabase.UpdateInfluxDatabase(config, &minuteReadouts, consumedWattHourBalanced60s, producedWattHourBalanced60s)
 			} else if config.DatabaseEnabled && acConfig.StoreSamples {
 				smartpiacDatabase.UpdateCalculatedInfluxDatabase(config, consumedWattHourBalanced60s, producedWattHourBalanced60s)
 			}
@@ -197,16 +271,20 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 			producedCounter = 0.0
 
 			// Update persistent counter files and read Values from not updated files
+			// Only the counter matching the direction of this minute is
+			// incremented, the other one is read back unchanged so that both
+			// totals can be published together.
 			if acConfig.CounterEnabled {
-				if wattHourBalancedAccu >= 0 {
-					consumedCounter = smartpiacFile.UpdateCounterFile(config, consumerCounterFile, math.Abs(wattHourBalancedAccu))
+				if minuteWattHourBalanced >= 0 {
+					consumedCounter = smartpiacFile.UpdateCounterFile(config, consumerCounterFile, math.Abs(minuteWattHourBalanced))
 					producedCounter = smartpiacFile.ReadCounterFile(config, producerCounterFile)
 				} else {
-					producedCounter = smartpiacFile.UpdateCounterFile(config, producerCounterFile, math.Abs(wattHourBalancedAccu))
+					producedCounter = smartpiacFile.UpdateCounterFile(config, producerCounterFile, math.Abs(minuteWattHourBalanced))
 					consumedCounter = smartpiacFile.ReadCounterFile(config, consumerCounterFile)
 				}
-				wattHourBalancedAccu = 0.0
 			}
+			// The calculated minute values are always published once per minute,
+			// independent of the readout publication interval.
 			if config.MQTTenabled {
 				smartpiacConnectivity.PublishMQTTCalculations(config, mqttclient, consumedWattHourBalanced60s, producedWattHourBalanced60s, consumedCounter, producedCounter)
 			}
@@ -216,6 +294,9 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 			}
 		}
 
+		// Reading all phases must fit into one sampling interval. If it does
+		// not, samples are effectively dropped and the loop drifts, so this is
+		// logged as an error.
 		delay := time.Since(startTime) - (time.Duration(1000/acConfig.Samplerate) * time.Millisecond)
 		if int64(delay) > 0 {
 			log.Errorf("Readout delayed: %s", delay)
@@ -225,6 +306,7 @@ func pollSmartPi(acConfig *config.SmartPiACConfig, config *config.SmartPiConfig,
 	}
 }
 
+// appVersion is set at build time via -ldflags.
 var appVersion = "No Version Provided"
 
 func init() {
@@ -236,11 +318,16 @@ func init() {
 	prometheus.MustRegister(versioncollector.NewCollector("smartpi"))
 }
 
+// main wires up the readout daemon: it loads both configuration files, starts
+// the measurement loop in the background and then serves the Prometheus metrics
+// endpoint in the foreground.
 func main() {
 
 	smartpiConfig := config.NewSmartPiConfig()
 	smartpiACConfig := config.NewSmartPiACConfig()
 
+	// Both configuration files are watched so that changes take effect without
+	// restarting the daemon.
 	go configWatcher(smartpiConfig)
 	go acConfigWatcher(smartpiACConfig)
 
@@ -261,6 +348,7 @@ func main() {
 
 	device, _ := smartpiacDevice.InitADE7878(smartpiACConfig)
 
+	// The measurement loop runs forever in its own goroutine.
 	go pollSmartPi(smartpiACConfig, smartpiConfig, device)
 
 	//http.Handle("/metrics", prometheus.Handler())
@@ -281,6 +369,9 @@ func main() {
 	}
 }
 
+// configWatcher reloads /etc/smartpi whenever the file is written to, so that
+// settings such as the MQTT publication interval can be changed at runtime.
+// It blocks forever and is meant to be run in its own goroutine.
 func configWatcher(config *config.SmartPiConfig) {
 	log.Debug("Start SmartPi watcher")
 	watcher, err := fsnotify.NewWatcher()
@@ -314,6 +405,9 @@ func configWatcher(config *config.SmartPiConfig) {
 	log.Debug("init done 3")
 }
 
+// acConfigWatcher does the same as configWatcher for the AC measurement
+// configuration in /etc/smartpiAC. It blocks forever and is meant to be run in
+// its own goroutine.
 func acConfigWatcher(acConfig *config.SmartPiACConfig) {
 	log.Debug("Start SmartPi watcher")
 	watcher, err := fsnotify.NewWatcher()


### PR DESCRIPTION
Readouts were published to MQTT and SmartPicloud on every sample. Both sinks can now be throttled to a configurable interval, so that only one condensed readout per interval is sent.

### New settings

Both default to `0`, which keeps the previous per-sample behaviour:

| Section | Key |
| --- | --- |
| `[mqtt]` | `mqtt_publish_interval` |
| `[smartpicloud]` | `smartpicloud_mqtt_publish_interval` |

They are separate so the cloud connection can be throttled more than the local broker.

### How the samples are condensed

A new `models.ReadoutAggregator` collects the samples of a window and condenses them into a single `ADE7878Readout`:

| Quantity | Handling |
| --- | --- |
| Current, voltage, active/reactive/apparent power, frequency | averaged |
| `Energyconsumption`, `Energyproduction`, `ActiveEnergy`, balanced energy | summed |
| cos phi | averaged power phasor, see below |

Summing the energy is what keeps a lower publication rate from losing energy.

**cos phi** is not averaged arithmetically: with a change of power direction within the window the individual values cancel each other out. The power phasor is averaged instead (`P_avg / hypot(P_avg, Q_avg)`), which keeps both magnitude and sign meaningful. Without any power in the window the phasor is undefined, so the plain mean is kept and cos phi does not jump at idle.

### Replaces ReadoutAccumulator

The aggregator replaces `ReadoutAccumulator`, which did the same job for the InfluxDB minute values but

- averaged cos phi arithmetically, and
- divided by a fixed `60*samplerate` instead of the actual sample count, which produced wrong minute values whenever the config watcher changed the samplerate at runtime.

Values written to InfluxDB are unchanged apart from `CosPhi1..3`; the field names stay the same, so existing dashboards keep working.

### Fixes the wattHourBalancedAccu reset

`wattHourBalancedAccu` was only reset when the persistent energy counters were enabled and otherwise grew without bounds, corrupting the `bEc`/`bEp` values in InfluxDB. The minute balance now comes from the aggregator, which is reset every minute regardless of the counter configuration.

### Verification

- `go build` and `gofmt` clean for `models`, `smartpi/config` and `smartpiac/...`.
- `go vet ./smartpiac/...` reports the same 16 pre-existing warnings as before the change (format strings in log calls).
- The aggregator maths was checked against the removed accumulator over a full 240-sample window (samplerate 4): current, voltage, power, frequency and energy agree to within 1e-9, so only cos phi changes.
