### PR TITLE
Allow a direct hex address for the digital-out module endpoint

### DIFF
--- a/src/smartpi/server/controllers/modules/digitalout.go
+++ b/src/smartpi/server/controllers/modules/digitalout.go
@@ -16,6 +16,29 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// parseModuleAddress resolves the bus address of a digital-out module from
+// the {address} path segment. A 0x-prefixed value (case-insensitive) is used
+// directly as the module's hexadecimal I2C bus address. Otherwise the value
+// is read as the on/off pattern of the module's three jumper switches (e.g.
+// "111" for all three on) - a binary number that the module's hardware
+// wiring maps onto its actual bus address via one's complement, which is
+// what the +0xD8 and bitwise-not below reproduce.
+func parseModuleAddress(address string) (uint8, error) {
+	if strings.HasPrefix(address, "0x") || strings.HasPrefix(address, "0X") {
+		addr, err := strconv.ParseUint(address[2:], 16, 8)
+		if err != nil {
+			return 0, err
+		}
+		return uint8(addr), nil
+	}
+
+	jumpers, err := strconv.ParseUint(address, 2, 8)
+	if err != nil {
+		return 0, err
+	}
+	return ^uint8(jumpers + 0xD8), nil
+}
+
 func (c ModulesController) SetDigitalout(mconf *config.Moduleconfig, conf *config.SmartPiConfig) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -42,18 +65,22 @@ func (c ModulesController) SetDigitalout(mconf *config.Moduleconfig, conf *confi
 		}
 
 		vars := mux.Vars(r)
-		address := utils.Reverse(vars["address"])
+		address := vars["address"]
 		portstring := vars["port"]
+		// The jumper encoding's bit order only makes sense reversed (see
+		// parseModuleAddress); a 0x-prefixed hex address is used exactly as
+		// given, reversing it would turn it into a different address.
+		if !strings.HasPrefix(address, "0x") && !strings.HasPrefix(address, "0X") {
+			address = utils.Reverse(address)
+		}
 		log.Debug("SetDigitalout: Vars: ", vars, " Address: ", address, " Portstring: ", portstring)
 
-		addr, err := strconv.ParseUint(address, 2, 8)
+		a, err := parseModuleAddress(address)
 		if err != nil {
 			error.Message = err.Error()
 			serverutils.RespondWithError(w, http.StatusBadRequest, error)
 			return
 		}
-
-		a := ^uint8(addr + 0xD8)
 
 		portstring = strings.TrimSpace(portstring)
 		if portstring[len(portstring)-1:] == ";" {
@@ -119,15 +146,12 @@ func (c ModulesController) ReadDigitalout(mconf *config.Moduleconfig, conf *conf
 
 		log.Debug("SetDigitalout: Vars: ", vars, " Address: ", address)
 
-		addr, err := strconv.ParseUint(address, 2, 8)
-
+		a, err := parseModuleAddress(address)
 		if err != nil {
 			error.Message = err.Error()
 			serverutils.RespondWithError(w, http.StatusBadRequest, error)
 			return
 		}
-
-		a := ^uint8(addr + 0xD8)
 
 		moduleRepo := modulesRepository.ModulesRepository{}
 

--- a/src/smartpi/server/controllers/modules/digitalout_test.go
+++ b/src/smartpi/server/controllers/modules/digitalout_test.go
@@ -1,0 +1,72 @@
+package modulescontrollers
+
+import "testing"
+
+func TestParseModuleAddressJumperEncoding(t *testing.T) {
+	// All three jumpers on ("111") is the example from the module's
+	// documentation: it must resolve to bus address 0x20.
+	got, err := parseModuleAddress("111")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0x20 {
+		t.Fatalf("jumpers \"111\" = 0x%02X, want 0x20", got)
+	}
+}
+
+func TestParseModuleAddressHexBypass(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint8
+	}{
+		{"0x20", 0x20},
+		{"0X20", 0x20},
+		{"0x00", 0x00},
+		{"0xff", 0xFF},
+		{"0xFF", 0xFF},
+		{"0x1a", 0x1A},
+	}
+	for _, c := range cases {
+		got, err := parseModuleAddress(c.in)
+		if err != nil {
+			t.Errorf("parseModuleAddress(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseModuleAddress(%q) = 0x%02X, want 0x%02X", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseModuleAddressInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"2",         // not a binary digit
+		"0x",        // hex prefix with nothing after it
+		"0xzz",      // not hex digits
+		"0x100",     // out of range for uint8
+		"111111111", // too many jumper bits for uint8 after +0xD8 is meaningless, but base parse itself should still succeed or fail consistently
+	}
+	for _, c := range cases {
+		if _, err := parseModuleAddress(c); err == nil {
+			t.Errorf("parseModuleAddress(%q) succeeded, want an error", c)
+		}
+	}
+}
+
+func TestParseModuleAddressHexDoesNotGoThroughJumperTransform(t *testing.T) {
+	// A hex address is the bus address itself - it must not also be run
+	// through the one's-complement jumper transform, which would silently
+	// address the wrong module.
+	got, err := parseModuleAddress("0x20")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transformed := ^uint8(0x20 + 0xD8)
+	if got == transformed {
+		t.Fatalf("0x20 accidentally matched the jumper transform's output 0x%02X - hex bypass is not being taken", transformed)
+	}
+	if got != 0x20 {
+		t.Fatalf("got 0x%02X, want 0x20 unchanged", got)
+	}
+}


### PR DESCRIPTION
`{address}` in `/api/v1/module/digitalout/{address}[/{port}]` previously only accepted the module's three jumper switches encoded as a binary string (e.g. `111` for all on), converted to the module's real I2C bus address via one's complement (`+0xD8`, then bitwise-not) - `111` becomes `0x20` this way.

A `0x`-prefixed value (case-insensitive, e.g. `0x20`) now bypasses that conversion entirely and is used as the bus address directly. Detected before `SetDigitalout`'s `utils.Reverse()` call, which exists for the jumper encoding only - reversing a hex string would turn it into a different address instead of leaving it alone.

`parseModuleAddress` factors the shared logic out of `SetDigitalout` and `ReadDigitalout`, which each had their own copy of the same `ParseUint`+transform.

### Verification

`go build`, `go vet`, `go test ./smartpi/server/controllers/modules/...` all pass. Tests cover the jumper example from the module docs (`111` -> `0x20`), the hex bypass (including uppercase `0X` and uppercase hex digits), invalid input, and that the hex path does not also run through the jumper transform.