### PR TITLE
Default the MQTT/SmartPicloud publish interval to 60 seconds

### DIFF
--- a/etc/smartpi
+++ b/etc/smartpi
@@ -48,7 +48,7 @@ mqtt_username         =
 mqtt_password         = 
 mqtt_topic            = 
 mqtt_qos              = 0
-mqtt_publish_interval = 0
+mqtt_publish_interval = 60
 
 [smartpicloud]
 smartpicloud_enabled               = false
@@ -60,7 +60,7 @@ smartpicloud_mqtt_username         =
 smartpicloud_mqtt_password         = 
 smartpicloud_mqtt_topic            = 
 smartpicloud_mqtt_qos              = 0
-smartpicloud_mqtt_publish_interval = 0
+smartpicloud_mqtt_publish_interval = 60
 
 [modbus]
 modbus_rtu_enabled   = false

--- a/src/smartpi/config/smartpiconfig_file.go
+++ b/src/smartpi/config/smartpiconfig_file.go
@@ -93,9 +93,9 @@ type SmartPiConfig struct {
 	MQTTpass         string
 	MQTTtopic        string
 	MQTTQoS          uint8
-	// MQTTinterval is the readout publication interval in seconds. Zero (the
-	// default) publishes every sample, any larger value publishes one
-	// aggregated readout per interval.
+	// MQTTinterval is the readout publication interval in seconds, default
+	// 60. Zero publishes every sample instead of aggregating; any other
+	// value publishes one aggregated readout per interval.
 	MQTTinterval int
 
 	// [smartpicloud]
@@ -108,9 +108,9 @@ type SmartPiConfig struct {
 	SmartpicloudMQTTpass         string
 	SmartpicloudMQTTtopic        string
 	SmartpicloudMQTTQoS          uint8
-	// SmartpicloudMQTTinterval is the readout publication interval in seconds
-	// for the cloud connection, independent of MQTTinterval. Zero publishes
-	// every sample.
+	// SmartpicloudMQTTinterval is the readout publication interval in
+	// seconds for the cloud connection, independent of MQTTinterval,
+	// default 60. Zero publishes every sample instead of aggregating.
 	SmartpicloudMQTTinterval int
 
 	// [modbus slave]
@@ -228,7 +228,7 @@ func (p *SmartPiConfig) ReadParameterFromFile() {
 	p.MQTTpass = cfg.Section("mqtt").Key("mqtt_password").String()
 	p.MQTTtopic = cfg.Section("mqtt").Key("mqtt_topic").String()
 	p.MQTTQoS = uint8(cfg.Section("mqtt").Key("mqtt_qos").MustUint(0))
-	p.MQTTinterval = cfg.Section("mqtt").Key("mqtt_publish_interval").MustInt(0)
+	p.MQTTinterval = cfg.Section("mqtt").Key("mqtt_publish_interval").MustInt(60)
 
 	// [smartpicloud]
 	p.SmartpicloudEnabled = cfg.Section("smartpicloud").Key("smartpicloud_enabled").MustBool(false)
@@ -239,7 +239,7 @@ func (p *SmartPiConfig) ReadParameterFromFile() {
 	p.SmartpicloudMQTTpass = cfg.Section("smartpicloud").Key("smartpicloud_mqtt_password").String()
 	p.SmartpicloudMQTTtopic = "smartpiac/" + cfg.Section("smartpicloud").Key("smartpicloud_mqtt_username").String()
 	p.SmartpicloudMQTTQoS = uint8(cfg.Section("smartpicloud").Key("smartpicloud_mqtt_qos").MustUint(0))
-	p.SmartpicloudMQTTinterval = cfg.Section("smartpicloud").Key("smartpicloud_mqtt_publish_interval").MustInt(0)
+	p.SmartpicloudMQTTinterval = cfg.Section("smartpicloud").Key("smartpicloud_mqtt_publish_interval").MustInt(60)
 
 	// [modbus slave]
 	p.ModbusRTUenabled = cfg.Section("modbus").Key("modbus_rtu_enabled").MustBool(false)


### PR DESCRIPTION
`MQTTinterval` and `SmartpicloudMQTTinterval` defaulted to `0` (publish every sample) when the ini key was missing entirely - the common case right after this became configurable, since existing installations' `/etc/smartpi` predate the key. Both now default to `60` instead, and the packaged `etc/smartpi` ships that value explicitly.

`MustInt`'s fallback only applies when the key is absent; an existing `/etc/smartpi` with the key already present, `0` included, is left alone - verified directly against `gopkg.in/ini.v1` rather than assumed:

```
missing file, missing key -> MustInt(60): 60
present, explicit 0        -> MustInt(60): 0
```

### Verification

`go build`, `go vet`, `gofmt` all clean on `smartpi/config`.