### PR TITLE
Add an analog-in module (MCP3424, 4-20mA / 0-10V, 4 channels)

### DIFF
--- a/src/models/modules/analoginstatus.go
+++ b/src/models/modules/analoginstatus.go
@@ -1,0 +1,29 @@
+package models
+
+// AnalogInChannel is one channel's reading, given both as a current (mA, for
+// a 4-20mA loop) and a voltage (V, for a 0-10V input). Which one is
+// physically meaningful depends on how that channel's jumper is wired on the
+// module - the server has no way to read that jumper, so both are always
+// reported and the caller uses whichever matches its own wiring.
+type AnalogInChannel struct {
+	Current float64 `json:"current"`
+	Voltage float64 `json:"voltage"`
+}
+
+// AnalogInStatus is the reading of one 4-channel analog-in module. Channels
+// is indexed 0-3 for physical channels 1-4.
+type AnalogInStatus struct {
+	Moduleaddress string             `json:"moduleaddress"`
+	Channels      [4]AnalogInChannel `json:"channels"`
+}
+
+// AnalogInChannelStatus is the reading of a single channel of an analog-in
+// module, as returned by the single-channel endpoint - deliberately not
+// AnalogInStatus with the other three channels left zeroed, which would be
+// indistinguishable from those channels genuinely reading zero.
+type AnalogInChannelStatus struct {
+	Moduleaddress string `json:"moduleaddress"`
+	// Channel is 1-4, the physical labelling on the module.
+	Channel int `json:"channel"`
+	AnalogInChannel
+}

--- a/src/smartpi/config/smartpiModulesconfig_file.go
+++ b/src/smartpi/config/smartpiModulesconfig_file.go
@@ -23,6 +23,9 @@ type Moduleconfig struct {
 	// [analogout420ma]
 	AllowedAnalogOut420mAUser []string
 
+	// [analogin]
+	AllowedAnalogInUser []string
+
 	// [etemperature]
 	AllowedEtemperatureUser       []string
 	EtemperatureI2CAddress        uint16
@@ -74,6 +77,12 @@ func (p *Moduleconfig) ReadParameterFromFile() {
 		p.AllowedAnalogOut420mAUser = append(p.AllowedAnalogOut420mAUser, "root", "smartpi")
 	}
 
+	// [analogin]
+	p.AllowedAnalogInUser = strings.Split(mcfg.Section("analogin").Key("allowed_user").String(), ",")
+	if len(p.AllowedAnalogInUser) == 0 {
+		p.AllowedAnalogInUser = append(p.AllowedAnalogInUser, "root", "smartpi")
+	}
+
 	// [etemperature]
 	p.AllowedEtemperatureUser = strings.Split(mcfg.Section("etemperature").Key("allowed_user").String(), ",")
 	if len(p.AllowedEtemperatureUser) == 0 {
@@ -117,6 +126,9 @@ func (p *Moduleconfig) SaveParameterToFile() {
 
 	// [analogout420ma]
 	_, merr = mcfg.Section("analogout420ma").NewKey("allowed_user", strings.Join(p.AllowedAnalogOut420mAUser, ","))
+
+	// [analogin]
+	_, merr = mcfg.Section("analogin").NewKey("allowed_user", strings.Join(p.AllowedAnalogInUser, ","))
 
 	//[etemperature]
 	_, merr = mcfg.Section("etemperature").NewKey("allowed_user", strings.Join(p.AllowedEtemperatureUser, ","))

--- a/src/smartpi/devicetoken/devicetoken.go
+++ b/src/smartpi/devicetoken/devicetoken.go
@@ -81,6 +81,7 @@ const touchInterval = time.Minute
 const (
 	ScopeDigitalOut  = "digitalout"
 	ScopeAnalogOut   = "analogout"
+	ScopeAnalogIn    = "analogin"
 	ScopeConfigRead  = "config:read"
 	ScopeConfigWrite = "config:write"
 	ScopeNetwork     = "network"
@@ -88,7 +89,7 @@ const (
 
 // Scopes lists every scope a token can be granted, in the order they should
 // be offered when creating one.
-var Scopes = []string{ScopeDigitalOut, ScopeAnalogOut, ScopeConfigRead, ScopeConfigWrite, ScopeNetwork}
+var Scopes = []string{ScopeDigitalOut, ScopeAnalogOut, ScopeAnalogIn, ScopeConfigRead, ScopeConfigWrite, ScopeNetwork}
 
 // ValidScope reports whether scope is one of the known Scopes.
 func ValidScope(scope string) bool {

--- a/src/smartpi/server/controllers/modules/analogin.go
+++ b/src/smartpi/server/controllers/modules/analogin.go
@@ -1,0 +1,123 @@
+package modulescontrollers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/nDenerserve/SmartPi/models"
+	config "github.com/nDenerserve/SmartPi/smartpi/config"
+	modulesRepository "github.com/nDenerserve/SmartPi/smartpi/server/repository/modules"
+	"github.com/nDenerserve/SmartPi/smartpi/server/serverutils"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+// ReadAnalogIn reads all four channels of an MCP3424-based analog input
+// module. Each channel is reported both as a current (mA, 4-20mA scale) and
+// a voltage (V, 0-10V scale) - see models.AnalogInChannel for why both are
+// always returned.
+func (c ModulesController) ReadAnalogIn(mconf *config.Moduleconfig, conf *config.SmartPiConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var error models.Error
+
+		// TokenVerifyMiddleWare already required the analogin scope for a
+		// device token, same reasoning as the other module endpoints - see
+		// digitalout.go.
+		if !serverutils.IsDeviceToken(r) {
+			user, err := serverutils.DecryptUserdataFromToken(r, conf)
+			if err != nil {
+				error.Message = err.Error()
+				serverutils.RespondWithError(w, http.StatusUnauthorized, error)
+				return
+			}
+			if !slices.Contains(mconf.AllowedAnalogInUser, user.Name) {
+				log.Warnf("User %s not allowed to read analogin (allowed: %v)", user.Name, mconf.AllowedAnalogInUser)
+				error.Message = "User not allowed"
+				serverutils.RespondWithError(w, http.StatusUnauthorized, error)
+				return
+			}
+		}
+
+		vars := mux.Vars(r)
+		addressStr := vars["address"]
+
+		address, err := parseHexOrDecimal(addressStr)
+		if err != nil {
+			error.Message = "Invalid address: " + err.Error() + ". Must be hex, e.g. 0x68"
+			serverutils.RespondWithError(w, http.StatusBadRequest, error)
+			return
+		}
+
+		moduleRepo := modulesRepository.ModulesRepository{}
+		status, err := moduleRepo.ReadAnalogIn(uint16(address), mconf)
+		status.Moduleaddress = addressStr
+		if err != nil {
+			error.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, error)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(status); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// ReadAnalogInChannel reads a single channel (1-4) of an MCP3424-based
+// analog input module - cheaper than ReadAnalogIn when only one channel is
+// needed, since only that channel's settle time is paid.
+func (c ModulesController) ReadAnalogInChannel(mconf *config.Moduleconfig, conf *config.SmartPiConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var error models.Error
+
+		if !serverutils.IsDeviceToken(r) {
+			user, err := serverutils.DecryptUserdataFromToken(r, conf)
+			if err != nil {
+				error.Message = err.Error()
+				serverutils.RespondWithError(w, http.StatusUnauthorized, error)
+				return
+			}
+			if !slices.Contains(mconf.AllowedAnalogInUser, user.Name) {
+				log.Warnf("User %s not allowed to read analogin (allowed: %v)", user.Name, mconf.AllowedAnalogInUser)
+				error.Message = "User not allowed"
+				serverutils.RespondWithError(w, http.StatusUnauthorized, error)
+				return
+			}
+		}
+
+		vars := mux.Vars(r)
+		addressStr := vars["address"]
+		channelStr := vars["channel"]
+
+		address, err := parseHexOrDecimal(addressStr)
+		if err != nil {
+			error.Message = "Invalid address: " + err.Error() + ". Must be hex, e.g. 0x68"
+			serverutils.RespondWithError(w, http.StatusBadRequest, error)
+			return
+		}
+
+		// Channels are addressed 1-4 in the URL (the physical labelling on
+		// the module), 0-3 internally.
+		channel, err := strconv.Atoi(channelStr)
+		if err != nil || channel < 1 || channel > 4 {
+			error.Message = "Invalid channel: must be a number between 1 and 4"
+			serverutils.RespondWithError(w, http.StatusBadRequest, error)
+			return
+		}
+
+		moduleRepo := modulesRepository.ModulesRepository{}
+		status, err := moduleRepo.ReadAnalogInChannel(uint16(address), channel-1, mconf)
+		status.Moduleaddress = addressStr
+		if err != nil {
+			error.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, error)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(status); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/src/smartpi/server/repository/modules/analogin.go
+++ b/src/smartpi/server/repository/modules/analogin.go
@@ -1,0 +1,136 @@
+package modulesRepository
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	models "github.com/nDenerserve/SmartPi/models/modules"
+	"github.com/nDenerserve/SmartPi/smartpi/config"
+
+	"periph.io/x/conn/v3/i2c"
+	"periph.io/x/conn/v3/i2c/i2creg"
+	"periph.io/x/host/v3"
+)
+
+// mcp3424ChannelConfig holds the MCP3424 configuration-register byte that
+// selects each of the four channels, reverse-engineered from a working
+// reference implementation (adr[] = {0x10, 0x30, 0x50, 0x70}):
+//
+//	bit 7    RDY       - don't-care on write in continuous mode
+//	bits 6:5 channel   - 00=1, 01=2, 10=3, 11=4
+//	bit 4    O/C       - 1 = continuous conversion
+//	bits 3:2 resolution - 00 = 12-bit (240 SPS)
+//	bits 1:0 gain      - 00 = x1
+//
+// Writing one of these switches the chip to continuously convert that
+// channel; the previous channel's conversions stop. There is no per-request
+// one-shot trigger to wait on - continuous mode is what makes the plain
+// fixed settle-then-read below workable.
+var mcp3424ChannelConfig = [4]byte{0x10, 0x30, 0x50, 0x70}
+
+// mcp3424SettleTime is how long to wait after switching the ADC to a channel
+// before its first conversion is ready. 12-bit resolution at 240 SPS needs
+// ~4.17ms; the reference implementation this was reverse-engineered from
+// slept a flat 1 second per channel instead, which would make one read of
+// all four channels take 4+ seconds. This keeps a generous margin over the
+// datasheet minimum without that cost.
+const mcp3424SettleTime = 20 * time.Millisecond
+
+// analogInCurrentDivisor converts the raw 16-bit ADC code into a current in
+// mA. Taken as-is from a working reference implementation - it is not
+// derived from the MCP3424's gain/Vref values in this codebase, so do not
+// "simplify" it without re-deriving and validating it against real hardware.
+const analogInCurrentDivisor = 908.0
+
+// ReadAnalogIn reads all four channels of an MCP3424-based analog input
+// module at address, returning both the current (mA) and voltage (V)
+// interpretation of each - see AnalogInChannel for why both are always
+// computed.
+func (m ModulesRepository) ReadAnalogIn(address uint16, conf *config.Moduleconfig) (models.AnalogInStatus, error) {
+	var status models.AnalogInStatus
+
+	dev, closeBus, err := openMCP3424(address, conf)
+	if err != nil {
+		return status, err
+	}
+	defer closeBus()
+
+	for ch := 0; ch < 4; ch++ {
+		current, err := readAnalogInChannel(dev, ch)
+		if err != nil {
+			return status, err
+		}
+		status.Channels[ch] = current
+	}
+
+	return status, nil
+}
+
+// ReadAnalogInChannel reads a single channel (0-3) of an MCP3424-based
+// analog input module at address. Switching only the requested channel
+// instead of all four is worthwhile because each channel switch costs a
+// settle wait.
+func (m ModulesRepository) ReadAnalogInChannel(address uint16, channel int, conf *config.Moduleconfig) (models.AnalogInChannelStatus, error) {
+	var status models.AnalogInChannelStatus
+	status.Channel = channel + 1
+
+	dev, closeBus, err := openMCP3424(address, conf)
+	if err != nil {
+		return status, err
+	}
+	defer closeBus()
+
+	reading, err := readAnalogInChannel(dev, channel)
+	status.AnalogInChannel = reading
+	return status, err
+}
+
+func openMCP3424(address uint16, conf *config.Moduleconfig) (*i2c.Dev, func(), error) {
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	bus, err := i2creg.Open(conf.I2CDevice)
+	if err != nil {
+		log.Errorf("failed to open I2C device %s: %v", conf.I2CDevice, err)
+		return nil, nil, err
+	}
+
+	dev := &i2c.Dev{Bus: bus, Addr: address}
+	return dev, func() { bus.Close() }, nil
+}
+
+func readAnalogInChannel(dev *i2c.Dev, channel int) (models.AnalogInChannel, error) {
+	if channel < 0 || channel > 3 {
+		return models.AnalogInChannel{}, fmt.Errorf("channel must be between 0 and 3, got %d", channel)
+	}
+
+	if err := dev.Tx([]byte{mcp3424ChannelConfig[channel]}, nil); err != nil {
+		return models.AnalogInChannel{}, fmt.Errorf("selecting channel %d: %w", channel+1, err)
+	}
+
+	time.Sleep(mcp3424SettleTime)
+
+	// 2 data bytes + 1 status/config-echo byte, matching the 12-bit
+	// continuous-mode read format. The status byte is read but, like the
+	// reference implementation, never inspected.
+	buf := make([]byte, 3)
+	if err := dev.Tx(nil, buf); err != nil {
+		return models.AnalogInChannel{}, fmt.Errorf("reading channel %d: %w", channel+1, err)
+	}
+
+	// Combined as a plain unsigned big-endian value, not sign-extended two's
+	// complement - matches the reference implementation exactly
+	// (`stemp=((string[0])*256+string[1])` in C, where string[] is unsigned
+	// char). For a unipolar 4-20mA/0-10V signal the raw code never goes
+	// negative, so this and a signed interpretation agree in practice.
+	raw := int(buf[0])<<8 + int(buf[1])
+
+	current := float64(raw) / analogInCurrentDivisor * 20.0
+	return models.AnalogInChannel{
+		Current: current,
+		Voltage: current / 4.0,
+	}, nil
+}

--- a/src/smartpi/server/repository/modules/analogin_test.go
+++ b/src/smartpi/server/repository/modules/analogin_test.go
@@ -1,0 +1,113 @@
+package modulesRepository
+
+import (
+	"testing"
+
+	"periph.io/x/conn/v3/i2c"
+	"periph.io/x/conn/v3/physic"
+)
+
+// fakeMCP3424Bus stands in for the real I2C bus. writes records every config
+// byte written (one per channel-select), and reply is returned verbatim for
+// every subsequent read, regardless of which channel it was meant for -
+// tests set it before exercising a channel.
+type fakeMCP3424Bus struct {
+	writes []byte
+	reply  []byte
+	txErr  error
+}
+
+func (f *fakeMCP3424Bus) String() string { return "fake" }
+
+func (f *fakeMCP3424Bus) Tx(addr uint16, w, r []byte) error {
+	if f.txErr != nil {
+		return f.txErr
+	}
+	if len(w) == 1 {
+		f.writes = append(f.writes, w[0])
+	}
+	if r != nil {
+		copy(r, f.reply)
+	}
+	return nil
+}
+
+func (f *fakeMCP3424Bus) SetSpeed(physic.Frequency) error { return nil }
+
+func TestReadAnalogInChannel_ConfigByteSelectsRightChannel(t *testing.T) {
+	bus := &fakeMCP3424Bus{reply: []byte{0x00, 0x00, 0x10}}
+	dev := &i2c.Dev{Bus: bus, Addr: 0x68}
+
+	for ch := 0; ch < 4; ch++ {
+		bus.writes = nil
+		if _, err := readAnalogInChannel(dev, ch); err != nil {
+			t.Fatalf("channel %d: %v", ch, err)
+		}
+		if len(bus.writes) != 1 || bus.writes[0] != mcp3424ChannelConfig[ch] {
+			t.Fatalf("channel %d: wrote %v, want [0x%02X]", ch, bus.writes, mcp3424ChannelConfig[ch])
+		}
+	}
+}
+
+func TestReadAnalogInChannel_ConversionFormula(t *testing.T) {
+	// raw = 0x0908 = 2312. current = 2312/908*20 = 50.9188... mA.
+	// Chosen so the divisor is unambiguous in the expected value if the
+	// wrong constant (e.g. 980) were used by mistake.
+	bus := &fakeMCP3424Bus{reply: []byte{0x09, 0x08, 0x00}}
+	dev := &i2c.Dev{Bus: bus, Addr: 0x68}
+
+	got, err := readAnalogInChannel(dev, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantCurrent := float64(0x0908) / 908.0 * 20.0
+	if got.Current != wantCurrent {
+		t.Fatalf("current = %v, want %v", got.Current, wantCurrent)
+	}
+	wantVoltage := wantCurrent / 4.0
+	if got.Voltage != wantVoltage {
+		t.Fatalf("voltage = %v, want %v", got.Voltage, wantVoltage)
+	}
+}
+
+func TestReadAnalogInChannel_RawCombinationIsUnsignedBigEndian(t *testing.T) {
+	// 0xFF in the high byte must contribute +65280, not a negative
+	// two's-complement value - matches the reference implementation, which
+	// combined the two bytes without any sign extension.
+	bus := &fakeMCP3424Bus{reply: []byte{0xFF, 0x00, 0x00}}
+	dev := &i2c.Dev{Bus: bus, Addr: 0x68}
+
+	got, err := readAnalogInChannel(dev, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Current <= 0 {
+		t.Fatalf("current = %v, want a large positive value (unsigned combination), not negative/zero", got.Current)
+	}
+}
+
+func TestReadAnalogInChannel_RejectsOutOfRangeChannel(t *testing.T) {
+	bus := &fakeMCP3424Bus{reply: []byte{0x00, 0x00, 0x00}}
+	dev := &i2c.Dev{Bus: bus, Addr: 0x68}
+
+	for _, ch := range []int{-1, 4, 99} {
+		if _, err := readAnalogInChannel(dev, ch); err == nil {
+			t.Fatalf("channel %d: expected an error, got none", ch)
+		}
+	}
+}
+
+func TestReadAnalogInChannel_PropagatesWriteError(t *testing.T) {
+	wantErr := &fakeTxError{"bus unavailable"}
+	bus := &fakeMCP3424Bus{txErr: wantErr}
+	dev := &i2c.Dev{Bus: bus, Addr: 0x68}
+
+	if _, err := readAnalogInChannel(dev, 0); err == nil {
+		t.Fatal("expected an error when the bus Tx fails, got none")
+	}
+}
+
+type fakeTxError struct{ msg string }
+
+func (e *fakeTxError) Error() string { return e.msg }

--- a/src/smartpi/server/server.go
+++ b/src/smartpi/server/server.go
@@ -128,6 +128,10 @@ func main() {
 	router.HandleFunc("/api/v1/module/analogout420ma/{address}/{current}", serverutils.TokenVerifyMiddleWare(modulesController.SetAnalogOut420mA(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogOut)).Methods("PUT")
 	router.HandleFunc("/api/v1/module/analogout420ma/{address}", serverutils.TokenVerifyMiddleWare(modulesController.ReadAnalogOut420mA(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogOut)).Methods("GET")
 
+	// Analog input module (MCP3424, 4x 4-20mA and/or 0-10V channels).
+	router.HandleFunc("/api/v1/module/analogin/{address}/{channel}", serverutils.TokenVerifyMiddleWare(modulesController.ReadAnalogInChannel(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogIn)).Methods("GET")
+	router.HandleFunc("/api/v1/module/analogin/{address}", serverutils.TokenVerifyMiddleWare(modulesController.ReadAnalogIn(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogIn)).Methods("GET")
+
 	router.PathPrefix("/assets").Handler(http.FileServer(http.Dir(smartpiConfig.DocRoot + "/")))
 	// Catch-all: Serve our JavaScript application's entry-point (index.html).
 	router.PathPrefix("/").HandlerFunc(IndexHandler(smartpiConfig.DocRoot + "/index.html"))


### PR DESCRIPTION
New endpoints:

```
GET /api/v1/module/analogin/{address}            all four channels
GET /api/v1/module/analogin/{address}/{channel}   one channel (1-4)
```

Each channel is reported both as a current (mA, 4-20mA scale) and a voltage (V, 0-10V scale). Per-channel jumpers on the physical module pick which one is actually wired, but that state is not readable over I2C, so both are always computed and returned - the caller uses whichever matches its own wiring, the same way an existing reference implementation for this module always computed and stored both.

### Where the protocol details come from

Not derived from the MCP3424 datasheet or guessed - reverse-engineered from a working reference implementation the user provided:

- `adr[] = {0x10, 0x30, 0x50, 0x70}`, the per-channel config bytes, decode to: continuous conversion, 12-bit resolution (240 SPS), gain x1, channel 1-4 respectively.
- Writing a channel's config byte switches the chip to continuously convert that channel; reading back 3 bytes afterwards (2 data + 1 status/config-echo byte, the latter never inspected, matching the reference) yields the raw ADC code.
- The two data bytes are combined as a plain unsigned big-endian 16-bit value, not sign-extended two's complement - matches the reference exactly.
- `current (mA) = raw / 908 * 20`; `voltage (V) = current / 4`. 908 is an empirical constant from the reference implementation - confirmed against it rather than assumed (an earlier prose description said 980, the actual reference code said 908).

One deliberate deviation: the reference slept a flat 1 second after switching channels before reading, which would make a four-channel read take 4+ seconds. 12-bit/240 SPS only needs ~4.17ms to settle; this uses 20ms as a generous margin instead.

New scope `analogin` and `AllowedAnalogInUser` config, following the digitalout/analogout420ma pattern exactly.

### Verification

`periph.io/x/conn/v3/i2c.Bus` is a small enough interface to fake directly, so this was tested against a fake bus rather than left unverified: the correct config byte is written per channel, the conversion formula matches the reference's constants exactly, the byte combination is confirmed unsigned rather than sign-extended, out-of-range channels are rejected, and a bus error propagates rather than being swallowed. `go build`/`vet`/`test` clean on every touched package except the ones that depend on PAM, which cannot build in this environment independent of this change - needs a `go build ./...`/`go test ./...` run where `security/pam_appl.h` is available before merging.