### PR TITLE
Add I2C bus scan endpoint

### DIFF
--- a/src/models/modules/i2cscanstatus.go
+++ b/src/models/modules/i2cscanstatus.go
@@ -1,0 +1,23 @@
+package models
+
+// I2CDeviceEntry is one address found occupied by an i2c scan.
+type I2CDeviceEntry struct {
+	// Address is the 7-bit bus address, formatted as "0xNN".
+	Address string `json:"address"`
+	// Status is "detected" for an address that acknowledged the probe, or
+	// "in_use" for one already claimed by a kernel driver (i2cdetect's "UU")
+	// and therefore not probed at all.
+	Status string `json:"status"`
+	// Hint is a best-effort guess at which SmartPi-supported chip sits at
+	// Address, based purely on its address range - never confirmed by
+	// reading any register, since none of MCP23017/ADE7878/MCP4725/MCP3424
+	// has a WHO_AM_I register to check against. Empty if the range isn't
+	// recognized.
+	Hint string `json:"hint,omitempty"`
+}
+
+// I2CScanStatus is the result of scanning one I2C bus for occupied addresses.
+type I2CScanStatus struct {
+	Bus     string           `json:"bus"`
+	Devices []I2CDeviceEntry `json:"devices"`
+}

--- a/src/smartpi/devicetoken/devicetoken.go
+++ b/src/smartpi/devicetoken/devicetoken.go
@@ -85,11 +85,12 @@ const (
 	ScopeConfigRead  = "config:read"
 	ScopeConfigWrite = "config:write"
 	ScopeNetwork     = "network"
+	ScopeI2CScan     = "i2c:scan"
 )
 
 // Scopes lists every scope a token can be granted, in the order they should
 // be offered when creating one.
-var Scopes = []string{ScopeDigitalOut, ScopeAnalogOut, ScopeAnalogIn, ScopeConfigRead, ScopeConfigWrite, ScopeNetwork}
+var Scopes = []string{ScopeDigitalOut, ScopeAnalogOut, ScopeAnalogIn, ScopeConfigRead, ScopeConfigWrite, ScopeNetwork, ScopeI2CScan}
 
 // ValidScope reports whether scope is one of the known Scopes.
 func ValidScope(scope string) bool {

--- a/src/smartpi/server/controllers/modules/i2c.go
+++ b/src/smartpi/server/controllers/modules/i2c.go
@@ -1,0 +1,37 @@
+package modulescontrollers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/nDenerserve/SmartPi/models"
+	config "github.com/nDenerserve/SmartPi/smartpi/config"
+	modulesRepository "github.com/nDenerserve/SmartPi/smartpi/server/repository/modules"
+	"github.com/nDenerserve/SmartPi/smartpi/server/serverutils"
+)
+
+// ScanI2C reports which addresses are occupied on the configured I2C bus.
+//
+// Unlike the other module endpoints (digitalout, analogin, analogout420ma)
+// this has no per-module username allowlist: it's a read-only diagnostic
+// over the whole bus, not an actuator or a per-module reading, so it doesn't
+// naturally belong to one module's AllowedXUser list. Access is gated purely
+// by TokenVerifyMiddleWare and the i2c:scan scope, the same as the network
+// scan endpoint (see controllers.Controller.ScanWifi).
+func (c ModulesController) ScanI2C(mconf *config.Moduleconfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var error models.Error
+
+		moduleRepo := modulesRepository.ModulesRepository{}
+		status, err := moduleRepo.ScanI2C(mconf)
+		if err != nil {
+			error.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, error)
+			return
+		}
+
+		if err := json.NewEncoder(w).Encode(status); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/src/smartpi/server/repository/modules/i2cscan.go
+++ b/src/smartpi/server/repository/modules/i2cscan.go
@@ -1,0 +1,128 @@
+package modulesRepository
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	models "github.com/nDenerserve/SmartPi/models/modules"
+	"github.com/nDenerserve/SmartPi/smartpi/config"
+	"github.com/nDenerserve/SmartPi/utils"
+)
+
+// i2cRowHeader matches one data row of `i2cdetect` output, e.g. "20: -- -- 27 ...".
+// The header row ("     0  1  2 ...") starts with whitespace, not a hex byte
+// followed by a colon, so it never matches and is skipped for free.
+var i2cRowHeader = regexp.MustCompile(`^([0-9a-f]{2}):(.*)$`)
+
+// ScanI2C probes every address on the configured I2C bus and reports which
+// ones are occupied.
+//
+// This shells out to `i2cdetect` (package i2c-tools, already a documented
+// install dependency, see readme.md) rather than probing the bus directly
+// with periph.io like the other modules do, deliberately with the -r flag:
+// i2cdetect's default probe mode sends a bare SMBus "quick write" command to
+// most addresses, which the tool's own manpage warns can alter state on some
+// chips. -r instead uses a read-only "receive byte" probe for every address,
+// which matters here because a MCP4725 DAC (analogout420ma module) may be
+// live on this same bus, actively driving a 4-20mA loop - a scan must never
+// risk writing to it.
+func (m ModulesRepository) ScanI2C(conf *config.Moduleconfig) (models.I2CScanStatus, error) {
+	var status models.I2CScanStatus
+	status.Bus = conf.I2CDevice
+
+	busNum, err := i2cBusNumber(conf.I2CDevice)
+	if err != nil {
+		return status, err
+	}
+
+	out, err := utils.RunCommand("i2cdetect", "-y", "-r", busNum)
+	if err != nil {
+		return status, fmt.Errorf("running i2cdetect (is the i2c-tools package installed?): %w", err)
+	}
+
+	status.Devices = parseI2CDetectOutput(out)
+	return status, nil
+}
+
+// i2cBusNumber extracts the bus number i2cdetect expects (e.g. "1") from the
+// full device path SmartPi's config stores (e.g. "/dev/i2c-1").
+func i2cBusNumber(device string) (string, error) {
+	const prefix = "/dev/i2c-"
+	if !strings.HasPrefix(device, prefix) {
+		return "", fmt.Errorf("cannot determine i2c bus number from %q: expected a path like %s<n>", device, prefix)
+	}
+	return strings.TrimPrefix(device, prefix), nil
+}
+
+// parseI2CDetectOutput parses the grid `i2cdetect -y -r <bus>` prints into
+// one entry per occupied address. Kept separate from ScanI2C so it can be
+// tested directly against canned output, without shelling out.
+func parseI2CDetectOutput(output string) []models.I2CDeviceEntry {
+	var entries []models.I2CDeviceEntry
+
+	for _, line := range strings.Split(output, "\n") {
+		match := i2cRowHeader.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+
+		rowBase, err := strconv.ParseInt(match[1], 16, 16)
+		if err != nil {
+			continue
+		}
+
+		// The row's cells follow immediately after a single fixed space
+		// (part of the "%02x: " prefix i2cdetect prints), each exactly 3
+		// characters wide ("-- ", "UU ", "27 ", or "   " for an address
+		// outside the probed range) - see the man page's example output.
+		cells := strings.TrimPrefix(match[2], " ")
+		for col := 0; col*3 < len(cells); col++ {
+			end := col*3 + 3
+			if end > len(cells) {
+				end = len(cells)
+			}
+			cell := strings.TrimSpace(cells[col*3 : end])
+			if cell == "" || cell == "--" {
+				continue
+			}
+
+			addr := int(rowBase) + col
+			entries = append(entries, models.I2CDeviceEntry{
+				Address: fmt.Sprintf("0x%02x", addr),
+				Status:  i2cCellStatus(cell),
+				Hint:    i2cAddressHint(addr),
+			})
+		}
+	}
+
+	return entries
+}
+
+func i2cCellStatus(cell string) string {
+	if cell == "UU" {
+		return "in_use"
+	}
+	return "detected"
+}
+
+// i2cAddressHint returns a best-effort, non-confirmed guess at which
+// SmartPi-supported chip an address belongs to, based on the address ranges
+// those chips ship in. See ScanI2C's comment on why this can never be more
+// than a hint: none of these chips exposes a register that positively
+// identifies it.
+func i2cAddressHint(addr int) string {
+	switch {
+	case addr >= 0x20 && addr <= 0x27:
+		return "MCP23017"
+	case addr == 0x38:
+		return "ADE7878"
+	case addr >= 0x60 && addr <= 0x63:
+		return "MCP4725"
+	case addr >= 0x68 && addr <= 0x6f:
+		return "MCP3424"
+	default:
+		return ""
+	}
+}

--- a/src/smartpi/server/repository/modules/i2cscan_test.go
+++ b/src/smartpi/server/repository/modules/i2cscan_test.go
@@ -1,0 +1,96 @@
+package modulesRepository
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildI2CDetectRow mimics the fixed-width row format i2cdetect prints:
+// "%02x:" followed by one 3-character cell per column (fewer than 16 for
+// row 0x70's 8-column tail). An empty string is a not-probed address
+// (printed as blank), "--" is no device, "UU" is in-use, anything else is
+// treated as a detected address byte.
+func buildI2CDetectRow(rowBase int, cells []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%02x:", rowBase)
+	for _, c := range cells {
+		if c == "" {
+			b.WriteString("   ")
+		} else {
+			fmt.Fprintf(&b, " %s", c)
+		}
+	}
+	return b.String()
+}
+
+func TestParseI2CDetectOutput_DetectsKnownChipRangesAndInUseAddresses(t *testing.T) {
+	lines := []string{
+		"     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f",
+		buildI2CDetectRow(0x00, []string{"", "", "", "--", "--", "--", "--", "--", "--", "--", "--", "--", "--", "--", "--", "--"}),
+		buildI2CDetectRow(0x20, []string{"--", "--", "--", "--", "--", "--", "--", "27", "--", "--", "--", "--", "--", "--", "--", "--"}),
+		buildI2CDetectRow(0x30, []string{"--", "--", "--", "--", "--", "--", "--", "--", "38", "--", "--", "--", "--", "--", "--", "--"}),
+		buildI2CDetectRow(0x50, []string{"--", "--", "--", "--", "--", "--", "--", "--", "--", "--", "UU", "--", "--", "--", "--", "--"}),
+		buildI2CDetectRow(0x60, []string{"60", "--", "--", "--", "--", "--", "--", "--", "68", "--", "--", "--", "--", "--", "--", "--"}),
+		buildI2CDetectRow(0x70, []string{"--", "--", "--", "--", "--", "--", "--", "77"}),
+	}
+	output := strings.Join(lines, "\n")
+
+	entries := parseI2CDetectOutput(output)
+
+	// 0x00-0x02 are reserved (blank cells, never printed as "--") and must
+	// not show up as detected; 0x5a is "UU" - claimed by a kernel driver,
+	// so it's reported as in_use with no chip hint; 0x77 exercises the
+	// short last row without a hint, since it falls outside every known
+	// chip's address range.
+	want := map[string]struct{ status, hint string }{
+		"0x27": {"detected", "MCP23017"},
+		"0x38": {"detected", "ADE7878"},
+		"0x5a": {"in_use", ""},
+		"0x60": {"detected", "MCP4725"},
+		"0x68": {"detected", "MCP3424"},
+		"0x77": {"detected", ""},
+	}
+
+	if len(entries) != len(want) {
+		t.Fatalf("got %d entries, want %d: %+v", len(entries), len(want), entries)
+	}
+	for _, e := range entries {
+		w, ok := want[e.Address]
+		if !ok {
+			t.Fatalf("unexpected address %s in result: %+v", e.Address, entries)
+		}
+		if e.Status != w.status || e.Hint != w.hint {
+			t.Fatalf("%s: got {%s %s}, want {%s %s}", e.Address, e.Status, e.Hint, w.status, w.hint)
+		}
+	}
+}
+
+func TestI2CBusNumber(t *testing.T) {
+	tests := []struct {
+		device  string
+		want    string
+		wantErr bool
+	}{
+		{"/dev/i2c-1", "1", false},
+		{"/dev/i2c-21", "21", false},
+		{"/dev/ttyS0", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := i2cBusNumber(tt.device)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("device %q: expected an error, got none", tt.device)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("device %q: unexpected error: %v", tt.device, err)
+		}
+		if got != tt.want {
+			t.Fatalf("device %q: got %q, want %q", tt.device, got, tt.want)
+		}
+	}
+}

--- a/src/smartpi/server/server.go
+++ b/src/smartpi/server/server.go
@@ -132,6 +132,11 @@ func main() {
 	router.HandleFunc("/api/v1/module/analogin/{address}/{channel}", serverutils.TokenVerifyMiddleWare(modulesController.ReadAnalogInChannel(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogIn)).Methods("GET")
 	router.HandleFunc("/api/v1/module/analogin/{address}", serverutils.TokenVerifyMiddleWare(modulesController.ReadAnalogIn(moduleConfig, smartpiConfig), smartpiConfig, deviceTokens, devicetoken.ScopeAnalogIn)).Methods("GET")
 
+	// I2C bus scan: reports occupied addresses on the configured bus (see
+	// repository/modules/i2cscan.go for why this shells out to i2cdetect
+	// instead of probing directly).
+	router.HandleFunc("/api/v1/i2c/scan", serverutils.TokenVerifyMiddleWare(modulesController.ScanI2C(moduleConfig), smartpiConfig, deviceTokens, devicetoken.ScopeI2CScan)).Methods("GET")
+
 	router.PathPrefix("/assets").Handler(http.FileServer(http.Dir(smartpiConfig.DocRoot + "/")))
 	// Catch-all: Serve our JavaScript application's entry-point (index.html).
 	router.PathPrefix("/").HandlerFunc(IndexHandler(smartpiConfig.DocRoot + "/index.html"))


### PR DESCRIPTION
Shells out to i2cdetect (-y -r, read-only probing) to report which addresses are occupied on the configured bus, with a best-effort, address-range-based hint at which supported chip (MCP23017, ADE7878, MCP4725, MCP3424) might be there - none of them expose a WHO_AM_I register, so this can never be more than a guess. New devicetoken scope i2c:scan gates GET /api/v1/i2c/scan.