### PR TITLE
Add self-update and apt package management API

### DIFF
--- a/etc/sudoers.d/smartpi-update
+++ b/etc/sudoers.d/smartpi-update
@@ -1,0 +1,17 @@
+# Allows the "smartpi" user - the account smartpiserver.service runs as, see
+# etc/systemd/system/smartpiserver.service - to manage system packages for
+# the web UI's settings "Update" tab (upload+install a smartpi .deb, and
+# search/install/upgrade packages from the repositories already configured
+# on the device).
+#
+# This is deliberately left unscoped rather than pinned to specific
+# arguments: apt-get install can already run arbitrary root-owned postinst
+# scripts for any package in a configured repository, so a sudoers pattern
+# restricting *which* arguments are allowed would not add real security, only
+# the appearance of it. Access is instead gated at the HTTP layer, by
+# requiring a logged-in session token - see RequireSessionToken in
+# src/smartpi/server/serverutils/serverutils.go - the same boundary already
+# relied on for changing a user's password (linuxtoolsRepository.ChangePassword)
+# and for network reconfiguration (see the NetworkManager polkit rules next
+# to this file).
+smartpi ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/systemd-run, /usr/bin/systemctl

--- a/readme.md
+++ b/readme.md
@@ -389,3 +389,8 @@ Or you can add it later via webgui:
  * fixed SmartPicloud MQTT topic and config file handling issues
  * added root and smartpi as default users for digitalout, analogout420ma, etemperature
  * new website build with updated views and assets
+
+ ### 09/07/26
+ * added a self-update API: upload a smartpi .deb to have it installed, backed by an async job status endpoint since installing smartpi itself can restart the webserver mid-request
+ * added an apt API to search, install and upgrade packages from the repositories already configured on the device
+ * requires the new etc/sudoers.d/smartpi-update rule (grants the smartpi user passwordless apt-get/systemd-run/systemctl)

--- a/src/smartpi/server/controllers/update.go
+++ b/src/smartpi/server/controllers/update.go
@@ -1,0 +1,281 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/nDenerserve/SmartPi/models"
+	"github.com/nDenerserve/SmartPi/smartpi/server/serverutils"
+	"github.com/nDenerserve/SmartPi/smartpi/update"
+)
+
+// maxUploadBytes bounds the size of an uploaded .deb, generously - see the
+// readme.md note on temporarily growing /var/tmp to 200M for updates - while
+// still keeping a runaway or malicious upload from filling the tmpfs it is
+// staged on.
+const maxUploadBytes = 200 << 20
+
+// updatePackageName is the package SmartPi's own release .deb is expected to
+// use. Version() reports its installed version alongside the running
+// binary's own build version.
+const updatePackageName = "smartpi"
+
+// GetUpdateVersion reports the version of the currently running smartpiserver
+// binary (baked in at build time, see the makefile's -ldflags) alongside the
+// version dpkg currently has on record for the smartpi package. The two can
+// disagree - most commonly right after an update whose install has not
+// finished yet, or on a device whose binaries were replaced by hand rather
+// than through a package - which is exactly why both are reported rather
+// than just one.
+func (c Controller) GetUpdateVersion(appVersion string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serverutils.ResponseJSON(w, struct {
+			RunningVersion   string `json:"runningVersion"`
+			InstalledVersion string `json:"installedVersion,omitempty"`
+		}{
+			RunningVersion:   appVersion,
+			InstalledVersion: update.InstalledVersion(updatePackageName),
+		})
+	}
+}
+
+// UploadUpdatePackage handles a .deb upload: it inspects the file, rejects
+// anything that is not a SmartPi package (see update.IsAllowedDebPackage),
+// and starts installing it. The HTTP response only confirms the install was
+// started - poll GetUpdateStatus for its outcome, since installing "smartpi"
+// itself can restart smartpiserver mid-request.
+func (c Controller) UploadUpdatePackage() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			errorObject.Message = "Uploaded file is too large or malformed."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			errorObject.Message = "Missing uploaded file (expected multipart field \"file\")."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+		defer file.Close()
+
+		if !strings.HasSuffix(strings.ToLower(header.Filename), ".deb") {
+			errorObject.Message = "Only .deb package files are supported."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		if err := os.MkdirAll(update.StagingDir, 0700); err != nil {
+			errorObject.Message = "Could not prepare the upload directory."
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+
+		// Each upload gets its own filename rather than a fixed one, so a
+		// second upload arriving while a previous install is still starting
+		// up can never overwrite the file that install is reading.
+		destPath := filepath.Join(update.StagingDir, fmt.Sprintf("upload-%d.deb", time.Now().UnixNano()))
+		if err := saveUploadedFile(file, destPath); err != nil {
+			errorObject.Message = "Could not store the uploaded file."
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+
+		pkgName, version, err := update.InspectDeb(destPath)
+		if err != nil {
+			os.Remove(destPath)
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		if !update.IsAllowedDebPackage(pkgName) {
+			os.Remove(destPath)
+			errorObject.Message = fmt.Sprintf("Package %q cannot be installed through upload; only smartpi packages are accepted.", pkgName)
+			serverutils.RespondWithError(w, http.StatusForbidden, errorObject)
+			return
+		}
+
+		previousVersion := update.InstalledVersion(pkgName)
+
+		job, err := update.StartInstall("deb", pkgName, previousVersion, version, destPath)
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusConflict, errorObject)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		serverutils.ResponseJSON(w, job)
+	}
+}
+
+func saveUploadedFile(src io.Reader, destPath string) error {
+	dest, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dest, src); err != nil {
+		dest.Close()
+		os.Remove(destPath)
+		return err
+	}
+	return dest.Close()
+}
+
+// GetUpdateStatus reports the state of the most recently started install
+// job, whether it was triggered by UploadUpdatePackage or InstallAptPackage.
+func (c Controller) GetUpdateStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		status, err := update.CurrentStatus()
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+		serverutils.ResponseJSON(w, status)
+	}
+}
+
+// RefreshAptCache runs apt-get update against the repositories already
+// configured on the device, so Search/Info/ListUpgradablePackages reflect
+// current versions.
+func (c Controller) RefreshAptCache() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		out, err := update.Refresh()
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+		serverutils.ResponseJSON(w, struct {
+			Output string `json:"output"`
+		}{Output: out})
+	}
+}
+
+// SearchAptPackages looks up ?q= against every package name known from the
+// repositories configured on the device.
+func (c Controller) SearchAptPackages() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		term := r.URL.Query().Get("q")
+		if term == "" {
+			errorObject.Message = "Missing query parameter \"q\"."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		results, err := update.Search(term)
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+		serverutils.ResponseJSON(w, results)
+	}
+}
+
+// GetAptPackageInfo reports one package's installed and candidate version.
+func (c Controller) GetAptPackageInfo() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		name := mux.Vars(r)["name"]
+		if !update.ValidPackageName(name) {
+			errorObject.Message = "Invalid package name."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		info, err := update.Info(name)
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+		serverutils.ResponseJSON(w, info)
+	}
+}
+
+// ListUpgradablePackages lists every package with a newer version available,
+// as of the last RefreshAptCache.
+func (c Controller) ListUpgradablePackages() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		results, err := update.Upgradable()
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
+			return
+		}
+		serverutils.ResponseJSON(w, results)
+	}
+}
+
+// installAptPackageRequest is the body of POST /api/v1/apt/install.
+type installAptPackageRequest struct {
+	Package string `json:"package"`
+	// Version pins a specific candidate; left empty, apt-get installs
+	// whatever the configured repositories currently offer as newest.
+	Version string `json:"version,omitempty"`
+}
+
+// InstallAptPackage installs (or upgrades) one package from the
+// repositories already configured on the device. Like UploadUpdatePackage,
+// this only starts the job - poll GetUpdateStatus for its outcome.
+func (c Controller) InstallAptPackage() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var errorObject models.Error
+
+		var req installAptPackageRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			errorObject.Message = "Malformed request body."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+		if !update.ValidPackageName(req.Package) {
+			errorObject.Message = "Invalid package name."
+			serverutils.RespondWithError(w, http.StatusBadRequest, errorObject)
+			return
+		}
+
+		target := req.Package
+		targetVersion := req.Version
+		if req.Version != "" {
+			target = req.Package + "=" + req.Version
+		} else if info, err := update.Info(req.Package); err == nil {
+			targetVersion = info.CandidateVersion
+		}
+
+		previousVersion := update.InstalledVersion(req.Package)
+
+		job, err := update.StartInstall("apt", req.Package, previousVersion, targetVersion, target)
+		if err != nil {
+			errorObject.Message = err.Error()
+			serverutils.RespondWithError(w, http.StatusConflict, errorObject)
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		serverutils.ResponseJSON(w, job)
+	}
+}

--- a/src/smartpi/server/server.go
+++ b/src/smartpi/server/server.go
@@ -137,6 +137,20 @@ func main() {
 	// instead of probing directly).
 	router.HandleFunc("/api/v1/i2c/scan", serverutils.TokenVerifyMiddleWare(modulesController.ScanI2C(moduleConfig), smartpiConfig, deviceTokens, devicetoken.ScopeI2CScan)).Methods("GET")
 
+	// Self-update (settings "Update" tab): upload+install a smartpi .deb, and
+	// search/install/upgrade packages from the repositories already
+	// configured on the device. Session-only, like the token management
+	// endpoints above - these are at least as privileged as minting a
+	// config:write device token, so a device token must never reach them.
+	router.HandleFunc("/api/v1/update/version", serverutils.RequireSessionToken(controller.GetUpdateVersion(appVersion), smartpiConfig)).Methods("GET")
+	router.HandleFunc("/api/v1/update/package", serverutils.RequireSessionToken(controller.UploadUpdatePackage(), smartpiConfig)).Methods("POST")
+	router.HandleFunc("/api/v1/update/status", serverutils.RequireSessionToken(controller.GetUpdateStatus(), smartpiConfig)).Methods("GET")
+	router.HandleFunc("/api/v1/apt/refresh", serverutils.RequireSessionToken(controller.RefreshAptCache(), smartpiConfig)).Methods("POST")
+	router.HandleFunc("/api/v1/apt/search", serverutils.RequireSessionToken(controller.SearchAptPackages(), smartpiConfig)).Methods("GET")
+	router.HandleFunc("/api/v1/apt/upgradable", serverutils.RequireSessionToken(controller.ListUpgradablePackages(), smartpiConfig)).Methods("GET")
+	router.HandleFunc("/api/v1/apt/package/{name}", serverutils.RequireSessionToken(controller.GetAptPackageInfo(), smartpiConfig)).Methods("GET")
+	router.HandleFunc("/api/v1/apt/install", serverutils.RequireSessionToken(controller.InstallAptPackage(), smartpiConfig)).Methods("POST")
+
 	router.PathPrefix("/assets").Handler(http.FileServer(http.Dir(smartpiConfig.DocRoot + "/")))
 	// Catch-all: Serve our JavaScript application's entry-point (index.html).
 	router.PathPrefix("/").HandlerFunc(IndexHandler(smartpiConfig.DocRoot + "/index.html"))

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -1,0 +1,462 @@
+// Package update implements SmartPi's self-update and package-management
+// backend: installing an uploaded smartpi .deb, and searching/installing/
+// upgrading packages from the repositories already configured on the device
+// (see the readme.md installation steps - influxdata, grafana, the Raspbian
+// base repos, ...).
+//
+// Every privileged step (apt-get, systemd-run) runs via sudo, the same
+// pattern linuxtoolsRepository.ChangePassword already relies on for
+// chpasswd - the smartpiserver process itself runs unprivileged as the
+// "smartpi" user (see etc/systemd/system/smartpiserver.service), so a
+// sudoers rule (etc/sudoers.d/smartpi-update) grants it exactly these
+// commands, nothing else.
+package update
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// StagingDir holds uploaded .deb files until apt-get has consumed them. It
+// lives on /var/tmp, which the readme.md setup mounts as tmpfs, so a file
+// left behind by a crashed upload never survives a reboot.
+const StagingDir = "/var/tmp/smartpi/update"
+
+// logDir and stateFile live on /var/smartpi instead, which is not tmpfs:
+// both need to survive the very service restart an update may trigger, so
+// that the status endpoint can still report how the last job ended once
+// smartpiserver comes back up.
+const (
+	logDir    = "/var/smartpi/update-logs"
+	stateFile = "/var/smartpi/update-job.json"
+)
+
+// packageNameRE matches a syntactically valid Debian package name (Debian
+// Policy §5.6.7). It is used to sanity-check package names before they are
+// ever placed on an apt-get command line, even though exec.Command already
+// passes each argument through untouched by any shell.
+var packageNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9+.-]*$`)
+
+// ValidPackageName reports whether name is a syntactically valid Debian
+// package name.
+func ValidPackageName(name string) bool {
+	return packageNameRE.MatchString(name)
+}
+
+// IsAllowedDebPackage reports whether name may be installed through the .deb
+// upload endpoint. Uploads are deliberately restricted to SmartPi's own
+// packages - "smartpi" itself, or a "smartpi-"-prefixed split package such as
+// a future "smartpi-modules" - so that the upload form can never be used to
+// sideload arbitrary software. Installing anything else still remains
+// possible through the apt endpoints below, which only ever reach packages
+// that are already listed in a repository configured on the device.
+func IsAllowedDebPackage(name string) bool {
+	return name == "smartpi" || strings.HasPrefix(name, "smartpi-")
+}
+
+// InspectDeb reads the package name and version out of a .deb file's control
+// data, without installing it.
+func InspectDeb(path string) (name, version string, err error) {
+	out, err := exec.Command("dpkg-deb", "-f", path, "Package", "Version").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("reading package metadata from %s: %w", filepath.Base(path), err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) < 2 || lines[0] == "" || lines[1] == "" {
+		return "", "", fmt.Errorf("could not determine package name and version from %s", filepath.Base(path))
+	}
+	return lines[0], lines[1], nil
+}
+
+// InstalledVersion returns the currently installed version of pkg, or "" if
+// it is not installed. A lookup failure - the normal case for a package that
+// was never installed - is deliberately not an error: dpkg-query exits
+// non-zero and writes "no packages found" to stderr for it, which is exactly
+// as informative as an empty result to every caller here.
+func InstalledVersion(pkg string) string {
+	out, err := exec.Command("dpkg-query", "-W", "-f=${Version}", pkg).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// Job describes one install run, persisted across process restarts (see
+// logDir/stateFile above) so its outcome can still be reported once
+// smartpiserver comes back up.
+type Job struct {
+	// Unit is the transient systemd unit the install runs under. Each job
+	// gets a fresh, unique unit name rather than reusing one, since a
+	// systemd unit stays loaded (and its name unavailable for reuse) after
+	// it exits until something explicitly resets or garbage-collects it -
+	// see StartInstall.
+	Unit string `json:"unit"`
+	// Kind is "deb" for an uploaded package, "apt" for one installed or
+	// upgraded from a configured repository.
+	Kind            string    `json:"kind"`
+	Package         string    `json:"package"`
+	PreviousVersion string    `json:"previousVersion,omitempty"`
+	TargetVersion   string    `json:"targetVersion,omitempty"`
+	StartedAt       time.Time `json:"startedAt"`
+}
+
+// Status is a Job plus its current outcome, as reported by systemd and the
+// job's captured log.
+type Status struct {
+	Job
+	// State is "idle" (no job has ever run), "running", "succeeded" or
+	// "failed".
+	State string `json:"state"`
+	// ExitCode is apt-get's exit status, meaningful only once State is
+	// "succeeded" or "failed".
+	ExitCode int `json:"exitCode"`
+	// Log is the tail of the job's combined stdout/stderr.
+	Log string `json:"log"`
+}
+
+// jobMu serializes StartInstall against itself: two concurrent uploads must
+// not both pass the "nothing is running" check and race to launch two
+// installs at once.
+var jobMu sync.Mutex
+
+// StartInstall launches `apt-get install -y <target>` as its own detached
+// systemd unit and returns immediately; poll CurrentStatus for the outcome.
+//
+// target is either a filesystem path to a .deb file, or an apt package
+// reference ("name" or "name=version"). pkg/previousVersion/targetVersion
+// are recorded purely for display - they play no part in what gets
+// installed.
+//
+// The install is deliberately not run as a plain child process of
+// smartpiserver: installing "smartpi" itself can restart smartpiserver.service
+// from a postinst script, and systemd's default KillMode (control-group)
+// would then kill every process in that service's cgroup, apt-get included,
+// corrupting the very install in progress. Running it via `systemd-run` moves
+// it into its own unit/cgroup first, and `--property=KillMode=none` on that
+// unit keeps it that way even if something explicitly signals it.
+func StartInstall(kind, pkg, previousVersion, targetVersion, target string) (Job, error) {
+	jobMu.Lock()
+	defer jobMu.Unlock()
+
+	if status, err := CurrentStatus(); err == nil && status.State == "running" {
+		return Job{}, fmt.Errorf("an update is already running (unit %s)", status.Unit)
+	}
+
+	if err := os.MkdirAll(logDir, 0700); err != nil {
+		return Job{}, fmt.Errorf("creating %s: %w", logDir, err)
+	}
+
+	unit := fmt.Sprintf("smartpi-update-%d", time.Now().UnixNano())
+	logPath := filepath.Join(logDir, unit+".log")
+
+	cmd := exec.Command("sudo", "systemd-run",
+		"--unit="+unit,
+		"--property=KillMode=none",
+		"--property=StandardOutput=file:"+logPath,
+		"--property=StandardError=file:"+logPath,
+		"--",
+		"apt-get", "install", "-y",
+		"-o", "Dpkg::Options::=--force-confold",
+		target,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return Job{}, fmt.Errorf("starting update: %s (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	job := Job{
+		Unit:            unit,
+		Kind:            kind,
+		Package:         pkg,
+		PreviousVersion: previousVersion,
+		TargetVersion:   targetVersion,
+		StartedAt:       time.Now().UTC(),
+	}
+	if err := saveJob(job); err != nil {
+		return job, fmt.Errorf("update started but its state could not be saved: %w", err)
+	}
+	return job, nil
+}
+
+// CurrentStatus reports the state of the most recently started job, or
+// State "idle" if none has ever run on this device.
+func CurrentStatus() (Status, error) {
+	job, ok, err := loadJob()
+	if err != nil {
+		return Status{}, err
+	}
+	if !ok {
+		return Status{State: "idle"}, nil
+	}
+
+	state, exitCode := unitState(job.Unit)
+	logTail, _ := tailFile(filepath.Join(logDir, job.Unit+".log"), 64*1024)
+
+	return Status{
+		Job:      job,
+		State:    state,
+		ExitCode: exitCode,
+		Log:      logTail,
+	}, nil
+}
+
+// unitState queries systemd for unit's current lifecycle state. Reading a
+// unit's status is an unprivileged operation, unlike starting or resetting
+// one, so this deliberately does not go through sudo.
+func unitState(unit string) (state string, exitCode int) {
+	out, err := exec.Command("systemctl", "show", unit,
+		"--property=ActiveState", "--property=SubState",
+		"--property=Result", "--property=ExecMainStatus",
+	).Output()
+	if err != nil {
+		return "unknown", 0
+	}
+
+	props := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		k, v, found := strings.Cut(scanner.Text(), "=")
+		if found {
+			props[k] = v
+		}
+	}
+
+	fmt.Sscanf(props["ExecMainStatus"], "%d", &exitCode)
+
+	switch props["ActiveState"] {
+	case "activating", "reloading":
+		return "running", exitCode
+	case "active":
+		if props["SubState"] == "running" {
+			return "running", exitCode
+		}
+	}
+
+	if props["Result"] == "success" {
+		return "succeeded", exitCode
+	}
+	if props["ActiveState"] == "" {
+		// The unit is no longer loaded at all (e.g. the device rebooted
+		// mid-install, or something ran `systemctl reset-failed`). Neither
+		// "succeeded" nor "failed" would be accurate, since we genuinely
+		// don't know.
+		return "unknown", exitCode
+	}
+	return "failed", exitCode
+}
+
+// saveJob persists job atomically: to a temp file in stateFile's directory,
+// then renamed into place, mirroring the pattern devicetoken.Store.save uses
+// for tokens.json.
+func saveJob(job Job) error {
+	data, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding job state: %w", err)
+	}
+
+	dir := filepath.Dir(stateFile)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".update-job-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, stateFile); err != nil {
+		return fmt.Errorf("replacing %s: %w", stateFile, err)
+	}
+	return nil
+}
+
+// loadJob reads back the last job saved by saveJob. ok is false if no job
+// has ever run on this device.
+func loadJob() (job Job, ok bool, err error) {
+	data, err := os.ReadFile(stateFile)
+	if os.IsNotExist(err) {
+		return Job{}, false, nil
+	}
+	if err != nil {
+		return Job{}, false, fmt.Errorf("reading %s: %w", stateFile, err)
+	}
+	if err := json.Unmarshal(data, &job); err != nil {
+		return Job{}, false, fmt.Errorf("parsing %s: %w", stateFile, err)
+	}
+	return job, true, nil
+}
+
+// tailFile returns the last maxBytes of the file at path, or its entirety if
+// smaller. Missing file (no output has been captured yet) is not an error.
+func tailFile(path string, maxBytes int64) (string, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	size := info.Size()
+	offset := int64(0)
+	truncated := false
+	if size > maxBytes {
+		offset = size - maxBytes
+		truncated = true
+	}
+	if _, err := f.Seek(offset, 0); err != nil {
+		return "", err
+	}
+
+	buf := make([]byte, size-offset)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return "", err
+	}
+
+	if truncated {
+		return "... (truncated)\n" + string(buf), nil
+	}
+	return string(buf), nil
+}
+
+// Refresh runs `apt-get update`, refreshing the package index from every
+// repository already configured on the device. It runs synchronously - it
+// never restarts a service, so it carries none of StartInstall's risk - and
+// returns its combined output for display.
+func Refresh() (string, error) {
+	out, err := exec.Command("sudo", "apt-get", "update").CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("apt-get update failed: %w", err)
+	}
+	return string(out), nil
+}
+
+// PackageSummary is one hit from Search.
+type PackageSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Search looks up term against every package name known from the configured
+// repositories (apt-cache search, restricted to names so a package's
+// description text can't produce surprising matches).
+func Search(term string) ([]PackageSummary, error) {
+	out, err := exec.Command("apt-cache", "search", "--names-only", term).Output()
+	if err != nil {
+		return nil, fmt.Errorf("apt-cache search failed: %w", err)
+	}
+	return parseSearchOutput(string(out)), nil
+}
+
+func parseSearchOutput(out string) []PackageSummary {
+	var results []PackageSummary
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		name, desc, _ := strings.Cut(line, " - ")
+		results = append(results, PackageSummary{Name: name, Description: desc})
+	}
+	return results
+}
+
+// PackageInfo is one package's installed vs. available version, as reported
+// by the repositories configured on the device.
+type PackageInfo struct {
+	Name             string `json:"name"`
+	InstalledVersion string `json:"installedVersion,omitempty"`
+	CandidateVersion string `json:"candidateVersion,omitempty"`
+}
+
+// Info reports name's installed and candidate (best available) version.
+func Info(name string) (PackageInfo, error) {
+	out, err := exec.Command("apt-cache", "policy", name).Output()
+	if err != nil {
+		return PackageInfo{}, fmt.Errorf("apt-cache policy failed: %w", err)
+	}
+	return parsePolicyOutput(name, string(out)), nil
+}
+
+func parsePolicyOutput(name, out string) PackageInfo {
+	info := PackageInfo{Name: name}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch {
+		case strings.HasPrefix(line, "Installed:"):
+			if v := strings.TrimSpace(strings.TrimPrefix(line, "Installed:")); v != "(none)" {
+				info.InstalledVersion = v
+			}
+		case strings.HasPrefix(line, "Candidate:"):
+			if v := strings.TrimSpace(strings.TrimPrefix(line, "Candidate:")); v != "(none)" {
+				info.CandidateVersion = v
+			}
+		}
+	}
+	return info
+}
+
+// UpgradablePackage is one package with a pending upgrade.
+type UpgradablePackage struct {
+	Name           string `json:"name"`
+	CurrentVersion string `json:"currentVersion"`
+	NewVersion     string `json:"newVersion"`
+}
+
+// upgradableLineRE matches one data line of `apt list --upgradable`, e.g.:
+// "smartpi/stable 1.2.4 armhf [upgradable from: 1.2.3]"
+var upgradableLineRE = regexp.MustCompile(`^(\S+)/\S+\s+(\S+)\s+\S+\s+\[upgradable from:\s*([^\]]+)\]`)
+
+// Upgradable lists every package with a newer version available in the
+// repositories configured on the device (as of the last Refresh).
+func Upgradable() ([]UpgradablePackage, error) {
+	// apt (unlike apt-get/apt-cache) prints a stability warning to stderr on
+	// every invocation ("apt does not have a stable CLI interface") - not a
+	// real error, so it is deliberately discarded here rather than folded
+	// into err via CombinedOutput.
+	out, err := exec.Command("apt", "list", "--upgradable").Output()
+	if err != nil {
+		return nil, fmt.Errorf("apt list --upgradable failed: %w", err)
+	}
+	return parseUpgradableOutput(string(out)), nil
+}
+
+func parseUpgradableOutput(out string) []UpgradablePackage {
+	var results []UpgradablePackage
+	for _, line := range strings.Split(out, "\n") {
+		m := upgradableLineRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		results = append(results, UpgradablePackage{
+			Name:           m[1],
+			NewVersion:     m[2],
+			CurrentVersion: m[3],
+		})
+	}
+	return results
+}

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -1,0 +1,121 @@
+package update
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsAllowedDebPackage(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"smartpi", true},
+		{"smartpi-modules", true},
+		{"smartpi-", true},
+		{"smartpiextra", false},
+		{"nodered", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsAllowedDebPackage(tt.name); got != tt.want {
+			t.Errorf("IsAllowedDebPackage(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestValidPackageName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"smartpi", true},
+		{"grafana", true},
+		{"lib32-foo.bar+baz", true},
+		{"", false},
+		{"-leadingdash", false},
+		{"Uppercase", false},
+		{"has space", false},
+		{"semi;colon", false},
+	}
+	for _, tt := range tests {
+		if got := ValidPackageName(tt.name); got != tt.want {
+			t.Errorf("ValidPackageName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestParseSearchOutput(t *testing.T) {
+	out := "smartpi - SmartPi energy monitor\n" +
+		"smartpi-modules - SmartPi optional hardware modules\n" +
+		"nodered - Node-RED\n"
+
+	got := parseSearchOutput(out)
+	want := []PackageSummary{
+		{Name: "smartpi", Description: "SmartPi energy monitor"},
+		{Name: "smartpi-modules", Description: "SmartPi optional hardware modules"},
+		{Name: "nodered", Description: "Node-RED"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseSearchOutput_Empty(t *testing.T) {
+	if got := parseSearchOutput(""); got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+}
+
+func TestParsePolicyOutput(t *testing.T) {
+	out := `smartpi:
+  Installed: 1.2.3
+  Candidate: 1.2.4
+  Version table:
+     1.2.4 500
+        500 https://repo.enerserve.eu stable/main armhf Packages
+ *** 1.2.3 100
+        100 /var/lib/dpkg/status
+`
+	got := parsePolicyOutput("smartpi", out)
+	want := PackageInfo{Name: "smartpi", InstalledVersion: "1.2.3", CandidateVersion: "1.2.4"}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParsePolicyOutput_NotInstalled(t *testing.T) {
+	out := `newpackage:
+  Installed: (none)
+  Candidate: 2.0.0
+  Version table:
+     2.0.0 500
+        500 https://repo.enerserve.eu stable/main armhf Packages
+`
+	got := parsePolicyOutput("newpackage", out)
+	want := PackageInfo{Name: "newpackage", CandidateVersion: "2.0.0"}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseUpgradableOutput(t *testing.T) {
+	out := `Listing... Done
+smartpi/stable 1.2.4 armhf [upgradable from: 1.2.3]
+grafana/stable 11.0.0 armhf [upgradable from: 10.9.0]
+`
+	got := parseUpgradableOutput(out)
+	want := []UpgradablePackage{
+		{Name: "smartpi", CurrentVersion: "1.2.3", NewVersion: "1.2.4"},
+		{Name: "grafana", CurrentVersion: "10.9.0", NewVersion: "11.0.0"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseUpgradableOutput_NoneUpgradable(t *testing.T) {
+	if got := parseUpgradableOutput("Listing... Done\n"); got != nil {
+		t.Fatalf("got %+v, want nil", got)
+	}
+}


### PR DESCRIPTION
Adds a backend for a future settings "Update" tab: uploading a smartpi .deb installs it, and a separate apt-backed API can search/install/ upgrade packages from the repositories already configured on the device. Installs run detached via systemd-run rather than as a plain child of smartpiserver, since installing "smartpi" itself can restart the webserver mid-request and systemd's default KillMode would otherwise kill the install along with it. Requires the new etc/sudoers.d/smartpi-update rule.