### PR TITLE
Add self-update and apt package management API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,3 +394,4 @@ Or you can add it later via webgui:
  * added a self-update API: upload a smartpi .deb to have it installed, backed by an async job status endpoint since installing smartpi itself can restart the webserver mid-request
  * added an apt API to search, install and upgrade packages from the repositories already configured on the device
  * requires the new etc/sudoers.d/smartpi-update rule (grants the smartpi user passwordless apt-get/systemd-run/systemctl)
+ * the .deb upload staging directory now defaults to /var/smartpi/update-uploads (not a tmpfs) and is configurable via [update] staging_dir in /etc/smartpi

--- a/src/smartpi/config/smartpiconfig_file.go
+++ b/src/smartpi/config/smartpiconfig_file.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nDenerserve/SmartPi/smartpi/update"
 	"github.com/nDenerserve/SmartPi/utils"
 
 	log "github.com/sirupsen/logrus"
@@ -119,6 +120,13 @@ type SmartPiConfig struct {
 	ModbusRTUAddress uint8
 	ModbusRTUDevice  string
 	ModbusTCPAddress string
+
+	// [update]
+	// UpdateStagingDir holds uploaded .deb files until they are installed
+	// (see package update). It must not point into a size-constrained tmpfs
+	// mount (e.g. the /var/tmp the readme.md setup mounts that way) - a real
+	// SmartPi release package does not reliably fit in one.
+	UpdateStagingDir string
 }
 
 var cfg *ini.File
@@ -248,6 +256,9 @@ func (p *SmartPiConfig) ReadParameterFromFile() {
 	p.ModbusRTUDevice = cfg.Section("modbus").Key("modbus_rtu_device_id").MustString("/dev/serial0")
 	p.ModbusTCPAddress = cfg.Section("modbus").Key("modbus_tcp_address").MustString(":502")
 
+	// [update]
+	p.UpdateStagingDir = cfg.Section("update").Key("staging_dir").MustString(update.DefaultStagingDir)
+
 }
 
 func (p *SmartPiConfig) SaveParameterToFile() {
@@ -325,6 +336,9 @@ func (p *SmartPiConfig) SaveParameterToFile() {
 	_, err = cfg.Section("modbus").NewKey("modbus_rtu_address", strconv.FormatUint(uint64(p.ModbusRTUAddress), 10))
 	_, err = cfg.Section("modbus").NewKey("modbus_rtu_device_id", p.ModbusRTUDevice)
 	_, err = cfg.Section("modbus").NewKey("modbus_tcp_address", p.ModbusTCPAddress)
+
+	// [update]
+	_, err = cfg.Section("update").NewKey("staging_dir", p.UpdateStagingDir)
 
 	tmpFile := "/tmp/smartpi_test"
 	err := cfg.SaveTo(tmpFile)

--- a/src/smartpi/server/controllers/update.go
+++ b/src/smartpi/server/controllers/update.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/nDenerserve/SmartPi/models"
 	"github.com/nDenerserve/SmartPi/smartpi/server/serverutils"
@@ -78,17 +79,20 @@ func (c Controller) UploadUpdatePackage() http.HandlerFunc {
 		}
 
 		if err := os.MkdirAll(update.StagingDir, 0700); err != nil {
+			log.Errorf("update: creating staging directory %s: %v", update.StagingDir, err)
 			errorObject.Message = "Could not prepare the upload directory."
 			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
 			return
 		}
+		update.CleanStaleUploads()
 
 		// Each upload gets its own filename rather than a fixed one, so a
 		// second upload arriving while a previous install is still starting
 		// up can never overwrite the file that install is reading.
 		destPath := filepath.Join(update.StagingDir, fmt.Sprintf("upload-%d.deb", time.Now().UnixNano()))
 		if err := saveUploadedFile(file, destPath); err != nil {
-			errorObject.Message = "Could not store the uploaded file."
+			log.Errorf("update: storing upload at %s: %v", destPath, err)
+			errorObject.Message = fmt.Sprintf("Could not store the uploaded file: %v", err)
 			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
 			return
 		}

--- a/src/smartpi/server/controllers/update.go
+++ b/src/smartpi/server/controllers/update.go
@@ -14,14 +14,14 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/nDenerserve/SmartPi/models"
+	"github.com/nDenerserve/SmartPi/smartpi/config"
 	"github.com/nDenerserve/SmartPi/smartpi/server/serverutils"
 	"github.com/nDenerserve/SmartPi/smartpi/update"
 )
 
-// maxUploadBytes bounds the size of an uploaded .deb, generously - see the
-// readme.md note on temporarily growing /var/tmp to 200M for updates - while
-// still keeping a runaway or malicious upload from filling the tmpfs it is
-// staged on.
+// maxUploadBytes bounds the size of an uploaded .deb, generously - while
+// still keeping a runaway or malicious upload from filling the staging
+// directory's filesystem (config.SmartPiConfig.UpdateStagingDir).
 const maxUploadBytes = 200 << 20
 
 // updatePackageName is the package SmartPi's own release .deb is expected to
@@ -53,9 +53,11 @@ func (c Controller) GetUpdateVersion(appVersion string) http.HandlerFunc {
 // and starts installing it. The HTTP response only confirms the install was
 // started - poll GetUpdateStatus for its outcome, since installing "smartpi"
 // itself can restart smartpiserver mid-request.
-func (c Controller) UploadUpdatePackage() http.HandlerFunc {
+func (c Controller) UploadUpdatePackage(conf *config.SmartPiConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var errorObject models.Error
+
+		stagingDir := conf.UpdateStagingDir
 
 		r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
 		if err := r.ParseMultipartForm(32 << 20); err != nil {
@@ -78,18 +80,18 @@ func (c Controller) UploadUpdatePackage() http.HandlerFunc {
 			return
 		}
 
-		if err := os.MkdirAll(update.StagingDir, 0700); err != nil {
-			log.Errorf("update: creating staging directory %s: %v", update.StagingDir, err)
+		if err := os.MkdirAll(stagingDir, 0700); err != nil {
+			log.Errorf("update: creating staging directory %s: %v", stagingDir, err)
 			errorObject.Message = "Could not prepare the upload directory."
 			serverutils.RespondWithError(w, http.StatusInternalServerError, errorObject)
 			return
 		}
-		update.CleanStaleUploads()
+		update.CleanStaleUploads(stagingDir)
 
 		// Each upload gets its own filename rather than a fixed one, so a
 		// second upload arriving while a previous install is still starting
 		// up can never overwrite the file that install is reading.
-		destPath := filepath.Join(update.StagingDir, fmt.Sprintf("upload-%d.deb", time.Now().UnixNano()))
+		destPath := filepath.Join(stagingDir, fmt.Sprintf("upload-%d.deb", time.Now().UnixNano()))
 		if err := saveUploadedFile(file, destPath); err != nil {
 			log.Errorf("update: storing upload at %s: %v", destPath, err)
 			errorObject.Message = fmt.Sprintf("Could not store the uploaded file: %v", err)

--- a/src/smartpi/server/server.go
+++ b/src/smartpi/server/server.go
@@ -143,7 +143,7 @@ func main() {
 	// endpoints above - these are at least as privileged as minting a
 	// config:write device token, so a device token must never reach them.
 	router.HandleFunc("/api/v1/update/version", serverutils.RequireSessionToken(controller.GetUpdateVersion(appVersion), smartpiConfig)).Methods("GET")
-	router.HandleFunc("/api/v1/update/package", serverutils.RequireSessionToken(controller.UploadUpdatePackage(), smartpiConfig)).Methods("POST")
+	router.HandleFunc("/api/v1/update/package", serverutils.RequireSessionToken(controller.UploadUpdatePackage(smartpiConfig), smartpiConfig)).Methods("POST")
 	router.HandleFunc("/api/v1/update/status", serverutils.RequireSessionToken(controller.GetUpdateStatus(), smartpiConfig)).Methods("GET")
 	router.HandleFunc("/api/v1/apt/refresh", serverutils.RequireSessionToken(controller.RefreshAptCache(), smartpiConfig)).Methods("POST")
 	router.HandleFunc("/api/v1/apt/search", serverutils.RequireSessionToken(controller.SearchAptPackages(), smartpiConfig)).Methods("GET")

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -27,14 +27,17 @@ import (
 )
 
 // StagingDir holds uploaded .deb files until apt-get has consumed them. It
-// lives on /var/tmp, which the readme.md setup mounts as tmpfs, so a file
-// left behind by a crashed upload never survives a reboot.
-const StagingDir = "/var/tmp/smartpi/update"
+// deliberately does not live under /var/tmp: the readme.md setup mounts that
+// as a tmpfs sized for logs and small scratch files (20-30M by default, see
+// its "Create tmpfs in /etc/fstab" section), which a real SmartPi release
+// package - several statically linked Go binaries in one .deb - does not
+// reliably fit in. /var/smartpi is the same persistent, non-tmpfs storage
+// devicetoken.DefaultPath already uses for tokens.json.
+const StagingDir = "/var/smartpi/update-uploads"
 
-// logDir and stateFile live on /var/smartpi instead, which is not tmpfs:
-// both need to survive the very service restart an update may trigger, so
-// that the status endpoint can still report how the last job ended once
-// smartpiserver comes back up.
+// logDir and stateFile also live on /var/smartpi: both need to survive the
+// very service restart an update may trigger, so that the status endpoint
+// can still report how the last job ended once smartpiserver comes back up.
 const (
 	logDir    = "/var/smartpi/update-logs"
 	stateFile = "/var/smartpi/update-job.json"
@@ -76,6 +79,27 @@ func InspectDeb(path string) (name, version string, err error) {
 		return "", "", fmt.Errorf("could not determine package name and version from %s", filepath.Base(path))
 	}
 	return lines[0], lines[1], nil
+}
+
+// CleanStaleUploads removes every .deb file left behind in StagingDir by a
+// previous upload, as long as no install job is currently running. It is
+// best-effort (errors are simply ignored) and meant to be called before
+// staging a new upload: now that StagingDir lives on persistent storage
+// rather than tmpfs (see above), an abandoned upload would otherwise sit
+// there forever instead of being reclaimed by the next reboot.
+func CleanStaleUploads() {
+	if status, err := CurrentStatus(); err != nil || status.State == "running" {
+		return
+	}
+	entries, err := os.ReadDir(StagingDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".deb") {
+			os.Remove(filepath.Join(StagingDir, e.Name()))
+		}
+	}
 }
 
 // InstalledVersion returns the currently installed version of pkg, or "" if

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -26,6 +26,26 @@ import (
 	"time"
 )
 
+// commandInC builds a command that runs with LC_ALL=C - and thus LANGUAGE
+// unset, which would otherwise override LC_ALL for gettext lookups - so its
+// output is always in the untranslated, English form every parser in this
+// file expects, regardless of the system's configured locale. Without this,
+// a device set up with e.g. German as its locale would have apt translate
+// strings this package matches literally, such as "[upgradable from: ...]"
+// in Upgradable, silently turning every match into no match at all.
+func commandInC(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "LC_ALL=") || strings.HasPrefix(kv, "LANGUAGE=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = append(env, "LC_ALL=C")
+	return cmd
+}
+
 // DefaultStagingDir is where uploaded .deb files are held until apt-get has
 // consumed them, unless overridden by config.SmartPiConfig.UpdateStagingDir.
 // It deliberately does not live under /var/tmp: the readme.md setup mounts
@@ -70,7 +90,7 @@ func IsAllowedDebPackage(name string) bool {
 // InspectDeb reads the package name and version out of a .deb file's control
 // data, without installing it.
 func InspectDeb(path string) (name, version string, err error) {
-	out, err := exec.Command("dpkg-deb", "-f", path, "Package", "Version").Output()
+	out, err := commandInC("dpkg-deb", "-f", path, "Package", "Version").Output()
 	if err != nil {
 		return "", "", fmt.Errorf("reading package metadata from %s: %w", filepath.Base(path), err)
 	}
@@ -127,7 +147,7 @@ func CleanStaleUploads(dir string) {
 // non-zero and writes "no packages found" to stderr for it, which is exactly
 // as informative as an empty result to every caller here.
 func InstalledVersion(pkg string) string {
-	out, err := exec.Command("dpkg-query", "-W", "-f=${Version}", pkg).Output()
+	out, err := commandInC("dpkg-query", "-W", "-f=${Version}", pkg).Output()
 	if err != nil {
 		return ""
 	}
@@ -391,7 +411,7 @@ func tailFile(path string, maxBytes int64) (string, error) {
 // never restarts a service, so it carries none of StartInstall's risk - and
 // returns its combined output for display.
 func Refresh() (string, error) {
-	out, err := exec.Command("sudo", "apt-get", "update").CombinedOutput()
+	out, err := commandInC("sudo", "apt-get", "update").CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("apt-get update failed: %w", err)
 	}
@@ -408,7 +428,7 @@ type PackageSummary struct {
 // repositories (apt-cache search, restricted to names so a package's
 // description text can't produce surprising matches).
 func Search(term string) ([]PackageSummary, error) {
-	out, err := exec.Command("apt-cache", "search", "--names-only", term).Output()
+	out, err := commandInC("apt-cache", "search", "--names-only", term).Output()
 	if err != nil {
 		return nil, fmt.Errorf("apt-cache search failed: %w", err)
 	}
@@ -416,7 +436,9 @@ func Search(term string) ([]PackageSummary, error) {
 }
 
 func parseSearchOutput(out string) []PackageSummary {
-	var results []PackageSummary
+	// Initialized rather than nil so a genuinely empty result still encodes
+	// to "[]", not "null" - the same reasoning as parseUpgradableOutput.
+	results := []PackageSummary{}
 	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
 		if line == "" {
 			continue
@@ -437,7 +459,7 @@ type PackageInfo struct {
 
 // Info reports name's installed and candidate (best available) version.
 func Info(name string) (PackageInfo, error) {
-	out, err := exec.Command("apt-cache", "policy", name).Output()
+	out, err := commandInC("apt-cache", "policy", name).Output()
 	if err != nil {
 		return PackageInfo{}, fmt.Errorf("apt-cache policy failed: %w", err)
 	}
@@ -481,7 +503,7 @@ func Upgradable() ([]UpgradablePackage, error) {
 	// every invocation ("apt does not have a stable CLI interface") - not a
 	// real error, so it is deliberately discarded here rather than folded
 	// into err via CombinedOutput.
-	out, err := exec.Command("apt", "list", "--upgradable").Output()
+	out, err := commandInC("apt", "list", "--upgradable").Output()
 	if err != nil {
 		return nil, fmt.Errorf("apt list --upgradable failed: %w", err)
 	}
@@ -489,7 +511,11 @@ func Upgradable() ([]UpgradablePackage, error) {
 }
 
 func parseUpgradableOutput(out string) []UpgradablePackage {
-	var results []UpgradablePackage
+	// Initialized rather than nil so a genuinely empty result still encodes
+	// to "[]", not "null" - which reads exactly like the locale bug this
+	// package used to have (see commandInC), where every line silently
+	// failed to match and looked the same as "nothing to upgrade".
+	results := []UpgradablePackage{}
 	for _, line := range strings.Split(out, "\n") {
 		m := upgradableLineRE.FindStringSubmatch(line)
 		if m == nil {

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -75,11 +75,28 @@ func InspectDeb(path string) (name, version string, err error) {
 		return "", "", fmt.Errorf("reading package metadata from %s: %w", filepath.Base(path), err)
 	}
 
-	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
-	if len(lines) < 2 || lines[0] == "" || lines[1] == "" {
+	fields := parseControlFields(string(out))
+	name, version = fields["Package"], fields["Version"]
+	if name == "" || version == "" {
 		return "", "", fmt.Errorf("could not determine package name and version from %s", filepath.Base(path))
 	}
-	return lines[0], lines[1], nil
+	return name, version, nil
+}
+
+// parseControlFields parses the "Field: value" lines dpkg-deb -f prints -
+// unlike, say, dpkg-query's -f format strings, it always echoes the field
+// name too, not just the value - into a name to value map.
+func parseControlFields(out string) map[string]string {
+	fields := map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		key, value, found := strings.Cut(scanner.Text(), ":")
+		if !found {
+			continue
+		}
+		fields[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return fields
 }
 
 // CleanStaleUploads removes every .deb file left behind in dir (the

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -26,14 +26,15 @@ import (
 	"time"
 )
 
-// StagingDir holds uploaded .deb files until apt-get has consumed them. It
-// deliberately does not live under /var/tmp: the readme.md setup mounts that
-// as a tmpfs sized for logs and small scratch files (20-30M by default, see
-// its "Create tmpfs in /etc/fstab" section), which a real SmartPi release
-// package - several statically linked Go binaries in one .deb - does not
-// reliably fit in. /var/smartpi is the same persistent, non-tmpfs storage
-// devicetoken.DefaultPath already uses for tokens.json.
-const StagingDir = "/var/smartpi/update-uploads"
+// DefaultStagingDir is where uploaded .deb files are held until apt-get has
+// consumed them, unless overridden by config.SmartPiConfig.UpdateStagingDir.
+// It deliberately does not live under /var/tmp: the readme.md setup mounts
+// that as a tmpfs sized for logs and small scratch files (20-30M by default,
+// see its "Create tmpfs in /etc/fstab" section), which a real SmartPi
+// release package - several statically linked Go binaries in one .deb -
+// does not reliably fit in. /var/smartpi is the same persistent, non-tmpfs
+// storage devicetoken.DefaultPath already uses for tokens.json.
+const DefaultStagingDir = "/var/smartpi/update-uploads"
 
 // logDir and stateFile also live on /var/smartpi: both need to survive the
 // very service restart an update may trigger, so that the status endpoint
@@ -81,23 +82,24 @@ func InspectDeb(path string) (name, version string, err error) {
 	return lines[0], lines[1], nil
 }
 
-// CleanStaleUploads removes every .deb file left behind in StagingDir by a
-// previous upload, as long as no install job is currently running. It is
-// best-effort (errors are simply ignored) and meant to be called before
-// staging a new upload: now that StagingDir lives on persistent storage
-// rather than tmpfs (see above), an abandoned upload would otherwise sit
-// there forever instead of being reclaimed by the next reboot.
-func CleanStaleUploads() {
+// CleanStaleUploads removes every .deb file left behind in dir (the
+// configured staging directory) by a previous upload, as long as no install
+// job is currently running. It is best-effort (errors are simply ignored)
+// and meant to be called before staging a new upload: now that staging
+// happens on persistent storage rather than tmpfs (see DefaultStagingDir),
+// an abandoned upload would otherwise sit there forever instead of being
+// reclaimed by the next reboot.
+func CleanStaleUploads(dir string) {
 	if status, err := CurrentStatus(); err != nil || status.State == "running" {
 		return
 	}
-	entries, err := os.ReadDir(StagingDir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
 	for _, e := range entries {
 		if !e.IsDir() && strings.HasSuffix(e.Name(), ".deb") {
-			os.Remove(filepath.Join(StagingDir, e.Name()))
+			os.Remove(filepath.Join(dir, e.Name()))
 		}
 	}
 }

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -45,6 +45,19 @@ func TestValidPackageName(t *testing.T) {
 	}
 }
 
+func TestParseControlFields(t *testing.T) {
+	// dpkg-deb -f <archive> Package Version echoes the field name on every
+	// line ("Package: smartpi"), not just the bare value - unlike, say,
+	// dpkg-query -W -f='${Version}'.
+	out := "Package: smartpi\nVersion: 2026.09.04-trixie\n"
+
+	got := parseControlFields(out)
+	want := map[string]string{"Package": "smartpi", "Version": "2026.09.04-trixie"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
 func TestParseSearchOutput(t *testing.T) {
 	out := "smartpi - SmartPi energy monitor\n" +
 		"smartpi-modules - SmartPi optional hardware modules\n" +

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -2,8 +2,29 @@ package update
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestCommandInC_ForcesCLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "de_DE.UTF-8")
+	t.Setenv("LANGUAGE", "de_DE:de")
+
+	cmd := commandInC("echo", "hi")
+
+	var lcAll string
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "LANGUAGE=") {
+			t.Fatalf("LANGUAGE should have been stripped, got %q", kv)
+		}
+		if name, value, ok := strings.Cut(kv, "="); ok && name == "LC_ALL" {
+			lcAll = value
+		}
+	}
+	if lcAll != "C" {
+		t.Fatalf("LC_ALL = %q, want \"C\"", lcAll)
+	}
+}
 
 func TestIsAllowedDebPackage(t *testing.T) {
 	tests := []struct {
@@ -75,8 +96,8 @@ func TestParseSearchOutput(t *testing.T) {
 }
 
 func TestParseSearchOutput_Empty(t *testing.T) {
-	if got := parseSearchOutput(""); got != nil {
-		t.Fatalf("got %+v, want nil", got)
+	if got := parseSearchOutput(""); len(got) != 0 {
+		t.Fatalf("got %+v, want empty", got)
 	}
 }
 
@@ -128,7 +149,7 @@ grafana/stable 11.0.0 armhf [upgradable from: 10.9.0]
 }
 
 func TestParseUpgradableOutput_NoneUpgradable(t *testing.T) {
-	if got := parseUpgradableOutput("Listing... Done\n"); got != nil {
-		t.Fatalf("got %+v, want nil", got)
+	if got := parseUpgradableOutput("Listing... Done\n"); len(got) != 0 {
+		t.Fatalf("got %+v, want empty", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Backend for a future settings "Update" tab: upload a `smartpi[-*]` `.deb` to have it installed, and search/install/upgrade packages from the repositories already configured on the device via a small apt API.
- Installs run detached via `systemd-run` (own unit/cgroup, `KillMode=none`) instead of as a plain child process of `smartpiserver`, since installing `smartpi` itself can restart the webserver mid-request and systemd's default `KillMode=control-group` would otherwise kill the install along with it. Job state/log persists under `/var/smartpi/` so status survives that restart.
- The `.deb` upload staging directory is configurable (`[update] staging_dir` in `/etc/smartpi`, default `/var/smartpi/update-uploads`) - deliberately not on the `/var/tmp` tmpfs the readme's setup mounts small by default, which a real multi-binary release package does not reliably fit in.
- New `etc/sudoers.d/smartpi-update` grants the unprivileged `smartpi` user passwordless `apt-get`/`systemd-run`/`systemctl`.
- All new endpoints require a session token (same trust level as the device-token management endpoints), never a device token.

### New endpoints
- `GET /api/v1/update/version` - running binary version + installed `smartpi` package version
- `POST /api/v1/update/package` - upload+install a `.deb` (multipart field `file`)
- `GET /api/v1/update/status` - current/last install job status (state, log tail, previous/target version)
- `POST /api/v1/apt/refresh`, `GET /api/v1/apt/search`, `GET /api/v1/apt/package/{name}`, `GET /api/v1/apt/upgradable`, `POST /api/v1/apt/install`

The frontend tab itself lives in the separate SmartPi-GUI repo and is not part of this change.

## Test plan
- [x] `go build ./...` and `go test ./smartpi/...` (PAM headers stubbed to work around a missing local `libpam0g-dev`)
- [x] Full build verified on the arm64 build host (rpi-compiler) with the genuine PAM headers, via `make buildsmartpiserver`
- [x] Uploaded a real `smartpi_2026.09.04-trixie_arm64.deb` end-to-end through the running web UI - confirmed working after fixing the staging directory (tmpfs too small) and the `dpkg-deb -f` output parsing (it prints `Field: value`, not bare values)