### PR TITLE
Only include the install log while an update is running

### DIFF
--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -183,8 +183,11 @@ type Status struct {
 	// ExitCode is apt-get's exit status, meaningful only once State is
 	// "succeeded" or "failed".
 	ExitCode int `json:"exitCode"`
-	// Log is the tail of the job's combined stdout/stderr.
-	Log string `json:"log"`
+	// Log is the tail of the job's combined stdout/stderr, populated only
+	// while State is "running" - once a job has finished, its log is no
+	// longer needed and would otherwise linger in every future status
+	// response as confusingly stale output from a job that is long over.
+	Log string `json:"log,omitempty"`
 }
 
 // jobMu serializes StartInstall against itself: two concurrent uploads must
@@ -262,7 +265,11 @@ func CurrentStatus() (Status, error) {
 	}
 
 	state, exitCode := unitState(job.Unit)
-	logTail, _ := tailFile(filepath.Join(logDir, job.Unit+".log"), 64*1024)
+
+	var logTail string
+	if state == "running" {
+		logTail, _ = tailFile(filepath.Join(logDir, job.Unit+".log"), 64*1024)
+	}
 
 	return Status{
 		Job:      job,


### PR DESCRIPTION
## Summary
- `GetUpdateStatus` (`/api/v1/update/status`) returned the tail of the last install job's log on every poll, regardless of state. Once a job finished (or a version was installed by hand outside the app), the log stuck around and made the normal status response look like an update was still in progress.
- The log is now only populated while `state == "running"`; it's omitted from the JSON entirely otherwise (`omitempty`).

## Test plan
- [x] `go build ./...` succeeds on the build server (local build fails there only due to unrelated missing PAM dev headers)
- [ ] Manual: trigger an install, confirm `log` is present while running and disappears from `/api/v1/update/status` once it succeeds/fails