### PR TITLE
Temporarily enlarge /var/tmp for apt-get installs/upgrades

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,10 @@ For secure 24/7 operation, we recommend that you also create a tmpf for the log 
 > If you want to update the system, you will need more space for /var/tmp.
 > Temporarily increase the memory with the following command:
 > sudo mount -o remount,size=200m /var/tmp
+>
+> The web UI's "Update" tab does this automatically around every install/
+> upgrade job it starts (and shrinks /var/tmp back down again afterwards),
+> so this manual step is only needed for updates run by hand at the shell.
     
 
 ##### Optimize the logfile (for bullseye):

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -236,10 +236,60 @@ func StartUpgradeAll() (Job, error) {
 	return startJob(job, []string{"upgrade", "-y", "-o", "Dpkg::Options::=--force-confold"})
 }
 
+// varTmpPath is where apt-get/dpkg keep scratch files - archive extraction,
+// etc. - while installing or upgrading packages.
+const varTmpPath = "/var/tmp"
+
+// varTmpEnlargedSize is the size aptGetScript remounts varTmpPath to, on a
+// system where it turns out to be a tmpfs, before running apt-get.
+const varTmpEnlargedSize = "200m"
+
+// aptGetScript builds the shell command startJob runs as its systemd unit's
+// main process: `apt-get <aptArgs...>`, wrapped so that if varTmpPath is
+// currently mounted as a tmpfs - the readme.md setup instructions have
+// installers do this, sized at only 20-30M by default (see
+// DefaultStagingDir's doc comment) - it is temporarily remounted large
+// enough for apt-get to download and unpack many packages at once (as
+// StartUpgradeAll can do), and remounted back to its normal, fstab-
+// configured size again once apt-get exits. A system that leaves varTmpPath
+// on disk is unaffected: the tmpfs check is a no-op there and nothing is
+// remounted.
+//
+// This lives inside the unit itself, rather than bracketing the
+// systemd-run call below in Go, because the update this triggers can
+// restart smartpiserver.service mid-job - installing "smartpi" itself does
+// exactly that - and the shrink-back step needs to run regardless of
+// whether the Go process that started the job is still around to see it
+// finish.
+func aptGetScript(aptArgs []string) string {
+	quoted := make([]string, len(aptArgs))
+	for i, a := range aptArgs {
+		quoted[i] = shellQuote(a)
+	}
+	aptGetCmd := "apt-get " + strings.Join(quoted, " ")
+
+	return fmt.Sprintf(`fstype=$(awk '$2 == "%[1]s" {print $3}' /proc/mounts)
+if [ "$fstype" = tmpfs ]; then
+  mount -o remount,size=%[2]s %[1]s
+  %[3]s
+  ec=$?
+  mount -o remount %[1]s
+  exit $ec
+fi
+%[3]s
+`, varTmpPath, varTmpEnlargedSize, aptGetCmd)
+}
+
+// shellQuote wraps s in single quotes for safe use as one word in a POSIX
+// shell command line, escaping any single quotes it contains.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // startJob is the shared implementation behind StartInstall and
-// StartUpgradeAll: it launches `apt-get <aptArgs...>` as its own detached
-// systemd unit and persists job (with Unit and StartedAt filled in) so
-// CurrentStatus can report its outcome.
+// StartUpgradeAll: it launches `apt-get <aptArgs...>` (see aptGetScript) as
+// its own detached systemd unit and persists job (with Unit and StartedAt
+// filled in) so CurrentStatus can report its outcome.
 //
 // The install is deliberately not run as a plain child process of
 // smartpiserver: installing "smartpi" itself can restart smartpiserver.service
@@ -263,15 +313,15 @@ func startJob(job Job, aptArgs []string) (Job, error) {
 	unit := fmt.Sprintf("smartpi-update-%d", time.Now().UnixNano())
 	logPath := filepath.Join(logDir, unit+".log")
 
-	args := append([]string{
+	args := []string{
 		"systemd-run",
 		"--unit=" + unit,
 		"--property=KillMode=none",
 		"--property=StandardOutput=file:" + logPath,
 		"--property=StandardError=file:" + logPath,
 		"--",
-		"apt-get",
-	}, aptArgs...)
+		"/bin/sh", "-c", aptGetScript(aptArgs),
+	}
 	if out, err := exec.Command("sudo", args...).CombinedOutput(); err != nil {
 		return Job{}, fmt.Errorf("starting update: %s (%s)", err, strings.TrimSpace(string(out)))
 	}

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -151,5 +152,46 @@ grafana/stable 11.0.0 armhf [upgradable from: 10.9.0]
 func TestParseUpgradableOutput_NoneUpgradable(t *testing.T) {
 	if got := parseUpgradableOutput("Listing... Done\n"); len(got) != 0 {
 		t.Fatalf("got %+v, want empty", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"simple", "'simple'"},
+		{"has space", "'has space'"},
+		{"pkg=1.2.3", "'pkg=1.2.3'"},
+		{"it's", `'it'\''s'`},
+	}
+	for _, tt := range tests {
+		if got := shellQuote(tt.in); got != tt.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestAptGetScript_ValidShell(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	script := aptGetScript([]string{"install", "-y", "smartpi's-package"})
+	cmd := exec.Command("sh", "-n")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("generated script is not valid sh: %v\n%s\n---\n%s", err, out, script)
+	}
+}
+
+func TestAptGetScript_QuotesArgsAndRunsBothBranches(t *testing.T) {
+	script := aptGetScript([]string{"install", "-y", "pkg=1.2.3"})
+
+	want := "apt-get 'install' '-y' 'pkg=1.2.3'"
+	if n := strings.Count(script, want); n != 2 {
+		t.Fatalf("expected the quoted apt-get command twice (tmpfs and non-tmpfs branch), got %d occurrences in:\n%s", n, script)
+	}
+	if !strings.Contains(script, varTmpPath) || !strings.Contains(script, varTmpEnlargedSize) {
+		t.Fatalf("script does not remount %s to %s:\n%s", varTmpPath, varTmpEnlargedSize, script)
 	}
 }


### PR DESCRIPTION
## Summary
- Several setups have `/var/tmp` as a small (20-30M) tmpfs, per the readme.md fstab instructions - too little for apt-get to download and unpack many packages at once, most noticeably during "upgrade all" (#286).
- `startJob` now runs `apt-get <args>` via a small shell script (`aptGetScript`) instead of invoking it directly: if `/var/tmp` is currently a tmpfs, it's remounted to 200M first, then shrunk back to its normal fstab-configured size afterwards. Systems where `/var/tmp` is a regular disk-backed directory are unaffected - nothing is remounted.
- This runs inside the systemd unit itself (not bracketed in Go around `systemd-run`), since installing "smartpi" can restart smartpiserver.service mid-job - the shrink-back needs to happen regardless of whether the Go process that started the job is still around when it finishes.
- Updated the matching readme.md warning to note this is now automatic from the web UI, and only still needed for updates run by hand at the shell.

## Test plan
- [x] New unit tests: `shellQuote` escaping, and `aptGetScript` producing valid POSIX shell (`sh -n`) that runs the quoted apt-get command in both the tmpfs and non-tmpfs branches
- [x] `go test ./smartpi/update/...` passes
- [x] `make style` / `make` pass on the build server (PAM present there)
- [ ] Manual: on a device with /var/tmp as tmpfs, trigger `/apt/upgrade-all` with several packages and confirm it no longer fails for lack of space, and that `/var/tmp` is back to its normal size afterwards