### PR TITLE
Retry systemctl show before reporting update job state "unknown"

### DIFF
--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -310,14 +310,42 @@ func CurrentStatus() (Status, error) {
 	}, nil
 }
 
+// unitStateExecRetries/unitStateExecRetryDelay bound how hard unitState
+// tries to run `systemctl show` before giving up - see unitState's doc
+// comment for why a single failed attempt isn't trusted.
+const (
+	unitStateExecRetries    = 3
+	unitStateExecRetryDelay = 200 * time.Millisecond
+)
+
 // unitState queries systemd for unit's current lifecycle state. Reading a
 // unit's status is an unprivileged operation, unlike starting or resetting
 // one, so this deliberately does not go through sudo.
+//
+// Spawning systemctl itself can transiently fail - fork/exec: resource
+// temporarily unavailable - while a large apt-get run (hundreds of
+// packages, their postinst scripts, ...) is under way, especially on the
+// memory-constrained hardware SmartPi typically runs on. A single failed
+// attempt used to be reported as state "unknown" straight away, which a
+// caller polling this can't tell apart from a genuinely lost job - even
+// though the apt-get run itself was still very much alive. Retrying a few
+// times first, rather than trusting one attempt, avoids that false
+// "unknown" for what is almost always a momentary blip.
 func unitState(unit string) (state string, exitCode int) {
-	out, err := exec.Command("systemctl", "show", unit,
-		"--property=ActiveState", "--property=SubState",
-		"--property=Result", "--property=ExecMainStatus",
-	).Output()
+	var out []byte
+	var err error
+	for attempt := 0; attempt < unitStateExecRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(unitStateExecRetryDelay)
+		}
+		out, err = exec.Command("systemctl", "show", unit,
+			"--property=ActiveState", "--property=SubState",
+			"--property=Result", "--property=ExecMainStatus",
+		).Output()
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return "unknown", 0
 	}


### PR DESCRIPTION
## Summary
Root-causes and fixes the transient `"state": "unknown"` reported by `/api/v1/update/status` during large `apt-get upgrade -y` runs (reported against SmartPi-GUI#7, which worked around the frontend symptom by not aborting job-status polling on "unknown").

- `unitState` determines a job's state by shelling out to `systemctl show <unit>`. It reported `"unknown"` immediately on the first failed attempt to even run that command - not from the unit itself being in a genuinely ambiguous state (that path, `ActiveState == ""`, is untouched by this change).
- Spawning any new process, including `systemctl`, can transiently fail with `fork/exec: resource temporarily unavailable` while a large apt-get run is under way - hundreds of packages, their postinst/preinst/debconf scripts all forking - especially on memory-constrained hardware like the Raspberry Pi SmartPi typically runs on. That transient exec failure was indistinguishable, from the API response alone, from a genuinely lost/dead job.
- `unitState` now retries up to 3 times (200ms apart) before falling back to `"unknown"`, so a momentary fork blip during a big upgrade no longer flips the reported state away from `"running"`.

## Test plan
- [x] `go test ./smartpi/update/...` passes
- [x] `make style` / `make` pass on the build server (PAM present there)
- [ ] Manual: trigger `/apt/upgrade-all` with a large package set (the reported case was 241 packages including systemd/libc6/perl) on constrained hardware, confirm `/update/status` no longer reports `"unknown"` mid-run