### PR TITLE
Include apt-get output in the "apt-get update failed" error

### DIFF
--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -529,7 +529,7 @@ func tailFile(path string, maxBytes int64) (string, error) {
 func Refresh() (string, error) {
 	out, err := commandInC("sudo", "apt-get", "update").CombinedOutput()
 	if err != nil {
-		return string(out), fmt.Errorf("apt-get update failed: %w", err)
+		return string(out), fmt.Errorf("apt-get update failed: %s (%s)", err, strings.TrimSpace(string(out)))
 	}
 	return string(out), nil
 }


### PR DESCRIPTION
## Summary
Reported symptom: `POST /apt/refresh` failing with only `"message": "apt-get update failed: exit status 100"` - no indication of what actually went wrong (bad repo signature, unreachable mirror, etc).

- `Refresh()` already runs `apt-get update` via `CombinedOutput()`, capturing its stdout+stderr into `out` - but on a non-zero exit it built the returned error from `err` alone (`%w`, i.e. just `exit status N`), discarding `out` entirely.
- The HTTP handler (`RefreshAptCache`) only ever surfaces `err.Error()` to the client, so that's genuinely all a caller could ever see.
- Now formats the error the same way `startJob`'s "starting update" error already does elsewhere in this package: exit status plus the trimmed captured output, e.g. `apt-get update failed: exit status 100 (E: The repository '...' is not signed.)`.

## Test plan
- [x] `go build`/`go test ./smartpi/update/...` pass
- [x] `make style` / `make` pass on the build server (PAM present there)
- [ ] Manual: trigger `/apt/refresh` against a broken repository config, confirm the error message now names the actual reason