### PR TITLE
Fix update jobs being reported "succeeded" before they even started

### DIFF
--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -219,11 +219,19 @@ func StartInstall(kind, pkg, previousVersion, targetVersion, target string) (Job
 	}, []string{"install", "-y", "-o", "Dpkg::Options::=--force-confold", target})
 }
 
-// StartUpgradeAll launches `apt-get upgrade -y`, upgrading every package
-// that currently has a newer version available in the repositories
-// configured on the device (as of the last Refresh) - the same set
-// Upgradable reports. Like StartInstall, it returns immediately; poll
-// CurrentStatus for the outcome.
+// StartUpgradeAll launches `apt-get dist-upgrade -y`, upgrading every
+// package that currently has a newer version available in the
+// repositories configured on the device (as of the last Refresh) - the
+// same set Upgradable reports. Like StartInstall, it returns immediately;
+// poll CurrentStatus for the outcome.
+//
+// dist-upgrade, not plain upgrade: apt-get upgrade deliberately never
+// installs or removes a package to satisfy one - it silently leaves
+// anything that would require that "kept back" instead, doing nothing for
+// it. That's routine for a kernel/firmware bump (a new linux-image-*
+// pulling in a new linux-headers-*, say), so upgrade alone would leave
+// most of what Upgradable/job.Packages just promised untouched, while
+// still exiting 0 as if there was nothing to do.
 func StartUpgradeAll() (Job, error) {
 	job := Job{Kind: "apt-all"}
 	if pkgs, err := Upgradable(); err == nil {
@@ -233,7 +241,7 @@ func StartUpgradeAll() (Job, error) {
 		}
 		job.Packages = names
 	}
-	return startJob(job, []string{"upgrade", "-y", "-o", "Dpkg::Options::=--force-confold"})
+	return startJob(job, []string{"dist-upgrade", "-y", "-o", "Dpkg::Options::=--force-confold"})
 }
 
 // varTmpPath is where apt-get/dpkg keep scratch files - archive extraction,
@@ -419,13 +427,11 @@ const (
 // "unknown" for what is almost always a momentary blip.
 //
 // jobOutcome only ever falls back to this once it finds no exit-code file
-// for the unit - i.e. the job hasn't genuinely finished (or crashed hard
-// enough to never write it, e.g. an OOM kill). So unlike jobOutcome, this
-// never reports "succeeded": at this point, ActiveState "inactive" with
-// Result "success" cannot mean genuine success (that always leaves the
-// exit-code file behind first, see aptGetScript) - it means systemd hasn't
-// finished loading/starting the unit yet, which is still "running" as far
-// as a caller is concerned.
+// for the unit. This never reports "succeeded": at this point, ActiveState
+// "inactive" with Result "success" cannot mean genuine success - that
+// always leaves the exit-code file behind first (see aptGetScript), which
+// jobOutcome would have already trusted over ever calling this. See the
+// switch below for what "inactive" (and friends) means instead.
 func unitState(unit string) (state string, exitCode int) {
 	var out []byte
 	var err error
@@ -456,18 +462,27 @@ func unitState(unit string) (state string, exitCode int) {
 	fmt.Sscanf(props["ExecMainStatus"], "%d", &exitCode)
 
 	switch props["ActiveState"] {
+	case "activating", "reloading", "active":
+		return "running", exitCode
 	case "failed":
 		return "failed", exitCode
-	case "":
-		// systemctl doesn't know about this unit at all (e.g. the device
-		// rebooted mid-install, or something ran `systemctl reset-failed`).
-		// "running" would not be accurate, since we genuinely don't know.
-		return "unknown", 0
 	default:
-		// "activating"/"reloading"/"active", or "inactive"/"deactivating"
-		// for a unit that hasn't started running yet - all still "running"
-		// from a caller's point of view.
-		return "running", exitCode
+		// "inactive"/"deactivating", or ActiveState empty - systemd has no
+		// record of the unit actually running right now. That's routine in
+		// the moment right after StartInstall/StartUpgradeAll launches a
+		// job, before it's had a chance to load - but it's exactly as
+		// consistent with a job that finished (successfully) and was
+		// garbage collected before ever getting to write its exit-code
+		// file, e.g. because it was started by an older smartpiserver build
+		// that predates aptGetScript recording one at all (the version this
+		// device was just upgraded from, say), the device rebooted
+		// mid-job, or `systemctl reset-failed` ran. There is no way to
+		// tell those apart from systemd state alone, so unlike the cases
+		// above, this is never reported as "running" - a real job's brief
+		// moment here resolves to "running" again within a poll or two
+		// anyway, which is a lot cheaper than a caller mistaking a stale
+		// reference for one still going.
+		return "unknown", 0
 	}
 }
 

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -261,7 +261,12 @@ const varTmpEnlargedSize = "200m"
 // exactly that - and the shrink-back step needs to run regardless of
 // whether the Go process that started the job is still around to see it
 // finish.
-func aptGetScript(aptArgs []string) string {
+//
+// It also records apt-get's exit code to exitCodePath itself, right before
+// exiting with that same code - see jobOutcome for why CurrentStatus needs
+// that, rather than relying only on systemd's own bookkeeping for the
+// unit.
+func aptGetScript(aptArgs []string, exitCodePath string) string {
 	quoted := make([]string, len(aptArgs))
 	for i, a := range aptArgs {
 		quoted[i] = shellQuote(a)
@@ -271,13 +276,15 @@ func aptGetScript(aptArgs []string) string {
 	return fmt.Sprintf(`fstype=$(awk '$2 == "%[1]s" {print $3}' /proc/mounts)
 if [ "$fstype" = tmpfs ]; then
   mount -o remount,size=%[2]s %[1]s
-  %[3]s
-  ec=$?
-  mount -o remount %[1]s
-  exit $ec
 fi
 %[3]s
-`, varTmpPath, varTmpEnlargedSize, aptGetCmd)
+ec=$?
+if [ "$fstype" = tmpfs ]; then
+  mount -o remount %[1]s
+fi
+echo $ec > %[4]s
+exit $ec
+`, varTmpPath, varTmpEnlargedSize, aptGetCmd, shellQuote(exitCodePath))
 }
 
 // shellQuote wraps s in single quotes for safe use as one word in a POSIX
@@ -312,6 +319,7 @@ func startJob(job Job, aptArgs []string) (Job, error) {
 
 	unit := fmt.Sprintf("smartpi-update-%d", time.Now().UnixNano())
 	logPath := filepath.Join(logDir, unit+".log")
+	exitCodePath := filepath.Join(logDir, unit+".exitcode")
 
 	args := []string{
 		"systemd-run",
@@ -319,8 +327,9 @@ func startJob(job Job, aptArgs []string) (Job, error) {
 		"--property=KillMode=none",
 		"--property=StandardOutput=file:" + logPath,
 		"--property=StandardError=file:" + logPath,
+		"--setenv=DEBIAN_FRONTEND=noninteractive",
 		"--",
-		"/bin/sh", "-c", aptGetScript(aptArgs),
+		"/bin/sh", "-c", aptGetScript(aptArgs, exitCodePath),
 	}
 	if out, err := exec.Command("sudo", args...).CombinedOutput(); err != nil {
 		return Job{}, fmt.Errorf("starting update: %s (%s)", err, strings.TrimSpace(string(out)))
@@ -345,7 +354,7 @@ func CurrentStatus() (Status, error) {
 		return Status{State: "idle"}, nil
 	}
 
-	state, exitCode := unitState(job.Unit)
+	state, exitCode := jobOutcome(job.Unit)
 
 	var logTail string
 	if state == "running" {
@@ -358,6 +367,33 @@ func CurrentStatus() (Status, error) {
 		ExitCode: exitCode,
 		Log:      logTail,
 	}, nil
+}
+
+// jobOutcome reports unit's outcome: "running" while it's still going,
+// "succeeded"/"failed" (with the exit code apt-get itself recorded - see
+// aptGetScript) once it's done, or "unknown" if that can't be determined.
+//
+// The exit-code file, when present, is trusted over asking systemd: a
+// transient unit that finished *successfully* is garbage-collected by
+// systemd within a few seconds of finishing - at which point `systemctl
+// show` reports the exact same defaults (ActiveState=inactive,
+// Result=success, ExecMainStatus=0) as a unit that was only just requested
+// and hasn't started running yet at all. Without the file, a poll landing
+// in either of those windows - right after StartInstall/StartUpgradeAll
+// launches a job, or late enough that a fast job already finished and got
+// collected - was indistinguishable from the other, and the former was
+// being misreported as "succeeded" before it had done anything. A unit
+// that instead *fails* stays loaded until explicitly reset, so this
+// ambiguity is specific to success.
+func jobOutcome(unit string) (state string, exitCode int) {
+	if raw, err := os.ReadFile(filepath.Join(logDir, unit+".exitcode")); err == nil {
+		fmt.Sscanf(strings.TrimSpace(string(raw)), "%d", &exitCode)
+		if exitCode == 0 {
+			return "succeeded", exitCode
+		}
+		return "failed", exitCode
+	}
+	return unitState(unit)
 }
 
 // unitStateExecRetries/unitStateExecRetryDelay bound how hard unitState
@@ -381,6 +417,15 @@ const (
 // though the apt-get run itself was still very much alive. Retrying a few
 // times first, rather than trusting one attempt, avoids that false
 // "unknown" for what is almost always a momentary blip.
+//
+// jobOutcome only ever falls back to this once it finds no exit-code file
+// for the unit - i.e. the job hasn't genuinely finished (or crashed hard
+// enough to never write it, e.g. an OOM kill). So unlike jobOutcome, this
+// never reports "succeeded": at this point, ActiveState "inactive" with
+// Result "success" cannot mean genuine success (that always leaves the
+// exit-code file behind first, see aptGetScript) - it means systemd hasn't
+// finished loading/starting the unit yet, which is still "running" as far
+// as a caller is concerned.
 func unitState(unit string) (state string, exitCode int) {
 	var out []byte
 	var err error
@@ -389,8 +434,7 @@ func unitState(unit string) (state string, exitCode int) {
 			time.Sleep(unitStateExecRetryDelay)
 		}
 		out, err = exec.Command("systemctl", "show", unit,
-			"--property=ActiveState", "--property=SubState",
-			"--property=Result", "--property=ExecMainStatus",
+			"--property=ActiveState", "--property=ExecMainStatus",
 		).Output()
 		if err == nil {
 			break
@@ -412,25 +456,19 @@ func unitState(unit string) (state string, exitCode int) {
 	fmt.Sscanf(props["ExecMainStatus"], "%d", &exitCode)
 
 	switch props["ActiveState"] {
-	case "activating", "reloading":
+	case "failed":
+		return "failed", exitCode
+	case "":
+		// systemctl doesn't know about this unit at all (e.g. the device
+		// rebooted mid-install, or something ran `systemctl reset-failed`).
+		// "running" would not be accurate, since we genuinely don't know.
+		return "unknown", 0
+	default:
+		// "activating"/"reloading"/"active", or "inactive"/"deactivating"
+		// for a unit that hasn't started running yet - all still "running"
+		// from a caller's point of view.
 		return "running", exitCode
-	case "active":
-		if props["SubState"] == "running" {
-			return "running", exitCode
-		}
 	}
-
-	if props["Result"] == "success" {
-		return "succeeded", exitCode
-	}
-	if props["ActiveState"] == "" {
-		// The unit is no longer loaded at all (e.g. the device rebooted
-		// mid-install, or something ran `systemctl reset-failed`). Neither
-		// "succeeded" nor "failed" would be accurate, since we genuinely
-		// don't know.
-		return "unknown", exitCode
-	}
-	return "failed", exitCode
 }
 
 // saveJob persists job atomically: to a temp file in stateFile's directory,

--- a/src/smartpi/update/update.go
+++ b/src/smartpi/update/update.go
@@ -191,9 +191,12 @@ type Status struct {
 	// "succeeded" or "failed".
 	ExitCode int `json:"exitCode"`
 	// Log is the tail of the job's combined stdout/stderr, populated only
-	// while State is "running" - once a job has finished, its log is no
+	// while State is "running" or "failed" - once a job has finished
+	// successfully (or there's nothing to show at all), its log is no
 	// longer needed and would otherwise linger in every future status
-	// response as confusingly stale output from a job that is long over.
+	// response as confusingly stale output from a job that is long over. A
+	// failed job is the exception: that's exactly when the log stops being
+	// stale noise and becomes the one place to see why.
 	Log string `json:"log,omitempty"`
 }
 
@@ -364,8 +367,13 @@ func CurrentStatus() (Status, error) {
 
 	state, exitCode := jobOutcome(job.Unit)
 
+	// Only omitted for "succeeded"/"idle"/"unknown": once a job is done and
+	// nothing went wrong, or there's nothing to show in the first place,
+	// the log is just stale noise on a routine status poll (see Log's doc
+	// comment) - but a "failed" job is exactly when its log stops being
+	// noise and becomes the one place to see why.
 	var logTail string
-	if state == "running" {
+	if state == "running" || state == "failed" {
 		logTail, _ = tailFile(filepath.Join(logDir, job.Unit+".log"), 64*1024)
 	}
 

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -244,18 +244,22 @@ func TestAptGetScript_RecordsRealExitCode(t *testing.T) {
 	}
 }
 
-// TestUnitState_UnknownUnitReportsRunningNotSucceeded guards against the
-// exact bug jobOutcome's doc comment describes: `systemctl show` on a unit
-// it has never heard of - indistinguishable, from ActiveState/Result
-// alone, from a unit that already finished successfully and was collected
-// - must not be read as "succeeded".
-func TestUnitState_UnknownUnitReportsRunningNotSucceeded(t *testing.T) {
+// TestUnitState_UnknownUnitReportsUnknown guards against the exact bug
+// jobOutcome's doc comment describes: `systemctl show` on a unit it has
+// never heard of is indistinguishable, from ActiveState alone, from a unit
+// that already finished successfully and was collected (both report
+// ActiveState "inactive"), or from one that was requested but hasn't
+// started yet. It must not be read as "succeeded" - nor as "running",
+// which would leave a genuinely stale job (e.g. one started by an older
+// smartpiserver build that predates aptGetScript's exit-code file) stuck
+// looking active forever.
+func TestUnitState_UnknownUnitReportsUnknown(t *testing.T) {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		t.Skip("systemctl not available")
 	}
 	state, exitCode := unitState("smartpi-update-test-unit-that-was-never-started")
-	if state == "succeeded" {
-		t.Fatalf(`unitState on a never-started unit = "succeeded" (exitCode %d), want anything else`, exitCode)
+	if state != "unknown" {
+		t.Fatalf(`unitState on a never-started unit = %q (exitCode %d), want "unknown"`, state, exitCode)
 	}
 }
 

--- a/src/smartpi/update/update_test.go
+++ b/src/smartpi/update/update_test.go
@@ -1,7 +1,9 @@
 package update
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -176,7 +178,7 @@ func TestAptGetScript_ValidShell(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")
 	}
-	script := aptGetScript([]string{"install", "-y", "smartpi's-package"})
+	script := aptGetScript([]string{"install", "-y", "smartpi's-package"}, "/var/smartpi/update-logs/unit.exitcode")
 	cmd := exec.Command("sh", "-n")
 	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -184,14 +186,84 @@ func TestAptGetScript_ValidShell(t *testing.T) {
 	}
 }
 
-func TestAptGetScript_QuotesArgsAndRunsBothBranches(t *testing.T) {
-	script := aptGetScript([]string{"install", "-y", "pkg=1.2.3"})
+func TestAptGetScript_QuotesArgsAndRecordsExitCode(t *testing.T) {
+	script := aptGetScript([]string{"install", "-y", "pkg=1.2.3"}, "/var/smartpi/update-logs/unit.exitcode")
 
 	want := "apt-get 'install' '-y' 'pkg=1.2.3'"
-	if n := strings.Count(script, want); n != 2 {
-		t.Fatalf("expected the quoted apt-get command twice (tmpfs and non-tmpfs branch), got %d occurrences in:\n%s", n, script)
+	if n := strings.Count(script, want); n != 1 {
+		t.Fatalf("expected the quoted apt-get command exactly once, got %d occurrences in:\n%s", n, script)
 	}
 	if !strings.Contains(script, varTmpPath) || !strings.Contains(script, varTmpEnlargedSize) {
 		t.Fatalf("script does not remount %s to %s:\n%s", varTmpPath, varTmpEnlargedSize, script)
 	}
+	if !strings.Contains(script, "echo $ec > '/var/smartpi/update-logs/unit.exitcode'") {
+		t.Fatalf("script does not record apt-get's exit code:\n%s", script)
+	}
+}
+
+// TestAptGetScript_RecordsRealExitCode actually runs the generated script
+// (against /bin/true and /bin/false standing in for apt-get, via a PATH
+// override) and checks the exit-code file it writes matches - this is what
+// jobOutcome relies on to tell a genuinely finished job apart from one
+// systemd hasn't started running yet, see jobOutcome's doc comment.
+func TestAptGetScript_RecordsRealExitCode(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	for _, tt := range []struct {
+		binary   string
+		wantCode string
+	}{
+		{"true", "0"},
+		{"false", "1"},
+	} {
+		t.Run(tt.binary, func(t *testing.T) {
+			dir := t.TempDir()
+			// aptGetScript always invokes "apt-get" by name; put a same-named
+			// stand-in on PATH ahead of the real one instead of teaching the
+			// function to run something else.
+			aptGetStub := filepath.Join(dir, "apt-get")
+			if err := os.Symlink(mustLookPath(t, tt.binary), aptGetStub); err != nil {
+				t.Fatal(err)
+			}
+			exitCodePath := filepath.Join(dir, "unit.exitcode")
+
+			cmd := exec.Command("sh", "-c", aptGetScript(nil, exitCodePath))
+			cmd.Env = append(os.Environ(), "PATH="+dir+":"+os.Getenv("PATH"))
+			out, _ := cmd.CombinedOutput()
+
+			got, err := os.ReadFile(exitCodePath)
+			if err != nil {
+				t.Fatalf("exit-code file was not written: %v\nscript output:\n%s", err, out)
+			}
+			if strings.TrimSpace(string(got)) != tt.wantCode {
+				t.Fatalf("exit-code file = %q, want %q", got, tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestUnitState_UnknownUnitReportsRunningNotSucceeded guards against the
+// exact bug jobOutcome's doc comment describes: `systemctl show` on a unit
+// it has never heard of - indistinguishable, from ActiveState/Result
+// alone, from a unit that already finished successfully and was collected
+// - must not be read as "succeeded".
+func TestUnitState_UnknownUnitReportsRunningNotSucceeded(t *testing.T) {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		t.Skip("systemctl not available")
+	}
+	state, exitCode := unitState("smartpi-update-test-unit-that-was-never-started")
+	if state == "succeeded" {
+		t.Fatalf(`unitState on a never-started unit = "succeeded" (exitCode %d), want anything else`, exitCode)
+	}
+}
+
+func mustLookPath(t *testing.T, name string) string {
+	t.Helper()
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("%s not available: %v", name, err)
+	}
+	return path
 }


### PR DESCRIPTION
## Summary
Reported: an "apt-all" job upgrading 16 (in an earlier report, 241) packages showed `"state": "succeeded", "exitCode": 0` right after being kicked off, while the packages it was supposed to upgrade were all still pending.

**Root cause**, confirmed by live testing on the build server: systemd garbage-collects a transient `systemd-run` unit within a few seconds of it finishing **successfully** (a **failed** unit stays loaded until explicitly reset - this asymmetry is key). Once collected, `systemctl show <unit>` reports exactly the same defaults - `ActiveState=inactive`, `Result=success`, `ExecMainStatus=0` - as a unit that was only just requested and hasn't started running *at all* yet (`LoadState=not-found` in both cases). `unitState` couldn't tell those two apart and reported the latter as `"succeeded"` too. Under the heavy CPU/IO load a large `apt-get` run causes (see #288), that pre-start window can stretch well past a moment, making it easy for a poll to land right in it.

**Fix:**
- `aptGetScript` now records apt-get's own exit code to a small sentinel file (`<unit>.exitcode` next to the job's log) right before exiting with it.
- `CurrentStatus` now goes through a new `jobOutcome`, which trusts that file over asking systemd anything at all. `unitState` is only ever consulted before the file exists - i.e. before the job has genuinely finished - so it can no longer report `"succeeded"`: only `"running"`, `"failed"` (unambiguous, per the asymmetry above), or `"unknown"` (systemctl doesn't know the unit at all, e.g. a reboot mid-install).

**Also included:** this carries forward the `DEBIAN_FRONTEND=noninteractive` fix from #288 - that PR's CircleCI run validated a second commit which turned out to land on the branch *after* the PR had already been merged, so its merge commit only picked up the first commit. Re-diffed against `master` and confirmed it was genuinely missing before adding it back here.

## Test plan
- [x] New regression test `TestUnitState_UnknownUnitReportsRunningNotSucceeded`: queries a unit systemd has never heard of and asserts the result is never `"succeeded"` - the exact scenario reproduced live on the build server (`systemctl show` on both a not-yet-started and an already-collected unit returns identical properties)
- [x] New test `TestAptGetScript_RecordsRealExitCode`: runs the generated script for real (against `true`/`false` standing in for `apt-get`) and checks the exit-code file it writes
- [x] `go test ./smartpi/update/...` passes
- [x] `make style` / `make` pass on the build server
- [ ] Manual: trigger `/apt/upgrade-all` with a large package set, confirm `/update/status` no longer reports `"succeeded"` immediately after starting